### PR TITLE
Apache environment variables

### DIFF
--- a/build-and-test.sh
+++ b/build-and-test.sh
@@ -22,4 +22,12 @@ sudo rm -rf user1999
 # Let's check that the "xdebug.remote_host" contains a value different from "no value"
 docker run -e PHP_EXTENSION_XDEBUG=1 thecodingmachine/php:${BRANCH}-${BRANCH_VARIANT} php -i | grep xdebug.remote_host| grep -v "no value"
 
+if [[ $VARIANT == apache* ]]; then
+    # Test if environment variables are passed to PHP
+    DOCKER_CID=`docker run -e MYVAR=foo -p "81:80" -d -v $(pwd):/var/www/html thecodingmachine/php:${BRANCH}-${BRANCH_VARIANT}`
+    RESULT=`curl http://localhost:81/tests/test.php`
+    [[ "$RESULT" = "foo" ]]
+    docker stop $DOCKER_CID
+fi
+
 echo "Tests passed with success"

--- a/tests/test.php
+++ b/tests/test.php
@@ -4,4 +4,3 @@ if (!isset($_SERVER['MYVAR'])) {
 } else {
     echo $_SERVER['MYVAR'];
 }
-echo getenv('MYVAR');

--- a/tests/test.php
+++ b/tests/test.php
@@ -1,0 +1,7 @@
+<?php
+if (!isset($_SERVER['MYVAR'])) {
+    echo "No variable set";
+} else {
+    echo $_SERVER['MYVAR'];
+}
+echo getenv('MYVAR');


### PR DESCRIPTION
This PR currently contains a test that breaks at fetching environment variables with Apache using $_SERVER. (not that it works with getenv)