### PR TITLE
Fixing remote_host detection on Docker for Mac

### DIFF
--- a/utils/docker-entrypoint-as-root.sh
+++ b/utils/docker-entrypoint-as-root.sh
@@ -56,11 +56,11 @@ if [ -z "$XDEBUG_REMOTE_HOST" ]; then
     # On mac, check that docker.for.mac.localhost exists. it true, use this.
     # Linux systems can report the value exists, but it is bound to localhost. In this case, ignore.
     set +e
-    host docker.for.mac.localhost &> /dev/null
+    host -t A docker.for.mac.localhost &> /dev/null
 
     if [[ $? == 0 ]]; then
         # The host exists.
-        DOCKER_FOR_MAC_REMOTE_HOST=`host docker.for.mac.localhost | awk '/has address/ { print $4 }'`
+        DOCKER_FOR_MAC_REMOTE_HOST=`host -t A docker.for.mac.localhost | awk '/has address/ { print $4 }'`
         if [ "$DOCKER_FOR_MAC_REMOTE_HOST" != "127.0.0.1" ]; then
             export XDEBUG_REMOTE_HOST=$DOCKER_FOR_MAC_REMOTE_HOST
         fi


### PR DESCRIPTION
Only asking for A records to limit problems with the "host" command (it returned an error on MacOS otherwise)