### PR TITLE
Add mbstring to list of available extensions

### DIFF
--- a/utils/generate_conf.php
+++ b/utils/generate_conf.php
@@ -6,7 +6,7 @@
 
 $availableExtensions = [
     'ast', 'bcmath', 'bz2', 'calendar', 'dba', 'enchant', 'ev', 'event', 'exif', 'ftp', 'gd', 'gettext', 'gmp', 'imap', 'intl', 'ldap',
-    'mcrypt', 'mysqli', 'opcache', 'pcntl', 'pdo_dblib', 'pdo_mysql', 'pdo_pgsql', 'pgsql', 'pspell',
+    'mbstring', 'mcrypt', 'mysqli', 'opcache', 'pcntl', 'pdo_dblib', 'pdo_mysql', 'pdo_pgsql', 'pgsql', 'pspell',
     'shmop', 'snmp', 'soap', 'sockets', 'sysvmsg', 'sysvsem', 'sysvshm', 'tidy', 'wddx', 'xmlrpc', 'xsl', 'zip',
     'xdebug', 'amqp', 'igbinary', 'memcached', 'mongodb', 'redis', 'apcu', 'yaml', 'weakref'
 ];


### PR DESCRIPTION
**Summary**

The extension is mentioned in the documentation as a default but an error occurs if it is mentioned in `PHP_EXTENSIONS` because it is not mentioned explicitly in the list of available extensions.

This adds the extension to this list.

**Test plan (required)**

Current behavior:

```
16:37 $ docker run -it --rm -e PHP_EXTENSIONS=mbstring thecodingmachine/php:7.2-v1-cli php --version
Invalid extension name found in PHP_EXTENSIONS environment variable. Found: 'mbstring'. Available extensions: ast, bcmath, bz2, calendar, dba, enchant, ev, event, exif, ftp, gd, gettext, gmp, imap, intl, ldap, mcrypt, mysqli, opcache, pcntl, pdo_dblib, pdo_mysql, pdo_pgsql, pgsql, pspell, shmop, snmp, soap, sockets, sysvmsg, sysvsem, sysvshm, tidy, wddx, xmlrpc, xsl, zip, xdebug, amqp, igbinary, memcached, mongodb, redis, apcu, yaml, weakref.
```

With change

```
16:38 $  docker run -it --rm -e PHP_EXTENSIONS=mbstring 553f817a4864 php --version
PHP Warning:  Module 'mbstring' already loaded in Unknown on line 0
PHP Warning:  Module 'mbstring' already loaded in Unknown on line 0
PHP Warning:  Module 'mbstring' already loaded in Unknown on line 0
PHP 7.2.5 (cli) (built: Apr 27 2018 00:49:18) ( NTS )
Copyright (c) 1997-2018 The PHP Group
Zend Engine v3.2.0, Copyright (c) 1998-2018 Zend Technologies
    with Zend OPcache v7.2.5, Copyright (c) 1999-2018, by Zend Technologies
```

**Checklist**

- [x] Have you followed the guidelines in our [CONTRIBUTING](CONTRIBUTING.md) guide?
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code