### PR TITLE
Compiled extensions cannot be disabled

### DIFF
--- a/Dockerfile.apache
+++ b/Dockerfile.apache
@@ -94,7 +94,6 @@ RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 # | Default PHP extensions to be enabled
 # |--------------------------------------------------------------------------
 ENV PHP_EXTENSION_APCU=1 \
-    PHP_EXTENSION_MBSTRING=1 \
     PHP_EXTENSION_MYSQLI=1 \
     PHP_EXTENSION_OPCACHE=1 \
     PHP_EXTENSION_PDO=1 \

--- a/Dockerfile.apache.node6
+++ b/Dockerfile.apache.node6
@@ -94,7 +94,6 @@ RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 # | Default PHP extensions to be enabled
 # |--------------------------------------------------------------------------
 ENV PHP_EXTENSION_APCU=1 \
-    PHP_EXTENSION_MBSTRING=1 \
     PHP_EXTENSION_MYSQLI=1 \
     PHP_EXTENSION_OPCACHE=1 \
     PHP_EXTENSION_PDO=1 \

--- a/Dockerfile.apache.node8
+++ b/Dockerfile.apache.node8
@@ -94,7 +94,6 @@ RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 # | Default PHP extensions to be enabled
 # |--------------------------------------------------------------------------
 ENV PHP_EXTENSION_APCU=1 \
-    PHP_EXTENSION_MBSTRING=1 \
     PHP_EXTENSION_MYSQLI=1 \
     PHP_EXTENSION_OPCACHE=1 \
     PHP_EXTENSION_PDO=1 \

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -94,7 +94,6 @@ RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 # | Default PHP extensions to be enabled
 # |--------------------------------------------------------------------------
 ENV PHP_EXTENSION_APCU=1 \
-    PHP_EXTENSION_MBSTRING=1 \
     PHP_EXTENSION_MYSQLI=1 \
     PHP_EXTENSION_OPCACHE=1 \
     PHP_EXTENSION_PDO=1 \

--- a/Dockerfile.cli.node6
+++ b/Dockerfile.cli.node6
@@ -94,7 +94,6 @@ RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 # | Default PHP extensions to be enabled
 # |--------------------------------------------------------------------------
 ENV PHP_EXTENSION_APCU=1 \
-    PHP_EXTENSION_MBSTRING=1 \
     PHP_EXTENSION_MYSQLI=1 \
     PHP_EXTENSION_OPCACHE=1 \
     PHP_EXTENSION_PDO=1 \

--- a/Dockerfile.cli.node8
+++ b/Dockerfile.cli.node8
@@ -94,7 +94,6 @@ RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 # | Default PHP extensions to be enabled
 # |--------------------------------------------------------------------------
 ENV PHP_EXTENSION_APCU=1 \
-    PHP_EXTENSION_MBSTRING=1 \
     PHP_EXTENSION_MYSQLI=1 \
     PHP_EXTENSION_OPCACHE=1 \
     PHP_EXTENSION_PDO=1 \

--- a/Dockerfile.fpm
+++ b/Dockerfile.fpm
@@ -94,7 +94,6 @@ RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 # | Default PHP extensions to be enabled
 # |--------------------------------------------------------------------------
 ENV PHP_EXTENSION_APCU=1 \
-    PHP_EXTENSION_MBSTRING=1 \
     PHP_EXTENSION_MYSQLI=1 \
     PHP_EXTENSION_OPCACHE=1 \
     PHP_EXTENSION_PDO=1 \

--- a/Dockerfile.fpm.node6
+++ b/Dockerfile.fpm.node6
@@ -94,7 +94,6 @@ RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 # | Default PHP extensions to be enabled
 # |--------------------------------------------------------------------------
 ENV PHP_EXTENSION_APCU=1 \
-    PHP_EXTENSION_MBSTRING=1 \
     PHP_EXTENSION_MYSQLI=1 \
     PHP_EXTENSION_OPCACHE=1 \
     PHP_EXTENSION_PDO=1 \

--- a/Dockerfile.fpm.node8
+++ b/Dockerfile.fpm.node8
@@ -94,7 +94,6 @@ RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 # | Default PHP extensions to be enabled
 # |--------------------------------------------------------------------------
 ENV PHP_EXTENSION_APCU=1 \
-    PHP_EXTENSION_MBSTRING=1 \
     PHP_EXTENSION_MYSQLI=1 \
     PHP_EXTENSION_OPCACHE=1 \
     PHP_EXTENSION_PDO=1 \

--- a/README.md
+++ b/README.md
@@ -83,9 +83,11 @@ RUN npm run build
 
 Below is a list of extensions available in this image:
 
-**Enabled by default:** apcu mbstring mysqli opcache pdo pdo_mysql redis zip soap
+**Compiled in PHP** (cannot be disabled): mbstring ftp mysqlnd
 
-**Available (can be enabled using environment variables):** amqp ast bcmath bz2 calendar dba enchant ev event exif ftp gd gettext gmp igbinary imap intl ldap mcrypt memcached mongodb pcntl pdo_dblib pdo_pgsql pgsql pspell shmop snmp sockets sysvmsg sysvsem sysvshm tidy wddx weakref(-beta) xdebug xmlrpc xsl yaml
+**Enabled by default:** apcu mysqli opcache pdo pdo_mysql redis zip soap
+
+**Available (can be enabled using environment variables):** amqp ast bcmath bz2 calendar dba enchant ev event exif gd gettext gmp igbinary imap intl ldap mcrypt memcached mongodb pcntl pdo_dblib pdo_pgsql pgsql pspell shmop snmp sockets sysvmsg sysvsem sysvshm tidy wddx weakref(-beta) xdebug xmlrpc xsl yaml
 
 ## Enabling/disabling extensions
 

--- a/build-and-test.sh
+++ b/build-and-test.sh
@@ -19,6 +19,17 @@ RESULT=`docker run -v $(pwd)/user1999:$CONTAINER_CWD thecodingmachine/php:${BRAN
 [[ "$RESULT" = "1999" ]]
 sudo rm -rf user1999
 
+# Let's check that mbstring, mysqlnd and ftp are enabled by default (they are compiled in PHP)
+docker run --rm thecodingmachine/php:${BRANCH}-${BRANCH_VARIANT} php -m | grep mbstring
+docker run --rm thecodingmachine/php:${BRANCH}-${BRANCH_VARIANT} php -m | grep mysqlnd
+docker run --rm thecodingmachine/php:${BRANCH}-${BRANCH_VARIANT} php -m | grep ftp
+
+# Let's check that mbstring cannot extension cannot be disabled
+set +e
+docker run --rm -e PHP_EXTENSION_MBSTRING=0 thecodingmachine/php:${BRANCH}-${BRANCH_VARIANT} php -i
+[[ "$?" = "1" ]]
+set -e
+
 # Let's check that the "xdebug.remote_host" contains a value different from "no value"
 docker run --rm -e PHP_EXTENSION_XDEBUG=1 thecodingmachine/php:${BRANCH}-${BRANCH_VARIANT} php -i | grep xdebug.remote_host| grep -v "no value"
 

--- a/images.yml
+++ b/images.yml
@@ -1,4 +1,5 @@
 php_version: 7.2
 xdebug_version: 2.6.0
-enabled_php_extensions: apcu mbstring mysqli opcache pdo pdo_mysql redis zip soap
-disabled_php_extensions: amqp ast bcmath bz2 calendar dba enchant ev event exif ftp gd gettext gmp igbinary imap intl ldap mcrypt memcached mongodb pcntl pdo_dblib pdo_pgsql pgsql pspell shmop snmp sockets sysvmsg sysvsem sysvshm tidy wddx weakref(-beta) xdebug xmlrpc xsl yaml
+compiled_php_extensions: mbstring ftp mysqlnd
+enabled_php_extensions: apcu mysqli opcache pdo pdo_mysql redis zip soap
+disabled_php_extensions: amqp ast bcmath bz2 calendar dba enchant ev event exif gd gettext gmp igbinary imap intl ldap mcrypt memcached mongodb pcntl pdo_dblib pdo_pgsql pgsql pspell shmop snmp sockets sysvmsg sysvsem sysvshm tidy wddx weakref(-beta) xdebug xmlrpc xsl yaml

--- a/utils/Dockerfile.blueprint
+++ b/utils/Dockerfile.blueprint
@@ -98,7 +98,6 @@ RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 # | Default PHP extensions to be enabled
 # |--------------------------------------------------------------------------
 ENV PHP_EXTENSION_APCU=1 \
-    PHP_EXTENSION_MBSTRING=1 \
     PHP_EXTENSION_MYSQLI=1 \
     PHP_EXTENSION_OPCACHE=1 \
     PHP_EXTENSION_PDO=1 \

--- a/utils/README.blueprint.md
+++ b/utils/README.blueprint.md
@@ -74,6 +74,8 @@ RUN npm run build
 
 Below is a list of extensions available in this image:
 
+**Compiled in PHP** (cannot be disabled): {{ $image.compiled_php_extensions }}
+
 **Enabled by default:** {{ $image.enabled_php_extensions }}
 
 **Available (can be enabled using environment variables):** {{ $image.disabled_php_extensions }}

--- a/utils/generate_conf.php
+++ b/utils/generate_conf.php
@@ -4,8 +4,12 @@
  * The script is run on each start of the container.
  */
 
+$compiledExtensions = [
+    'ftp', 'mysqlnd', 'mbstring'
+];
+
 $availableExtensions = [
-    'ast', 'bcmath', 'bz2', 'calendar', 'dba', 'enchant', 'ev', 'event', 'exif', 'ftp', 'gd', 'gettext', 'gmp', 'imap', 'intl', 'ldap',
+    'ast', 'bcmath', 'bz2', 'calendar', 'dba', 'enchant', 'ev', 'event', 'exif', 'gd', 'gettext', 'gmp', 'imap', 'intl', 'ldap',
     'mcrypt', 'mysqli', 'opcache', 'pcntl', 'pdo_dblib', 'pdo_mysql', 'pdo_pgsql', 'pgsql', 'pspell',
     'shmop', 'snmp', 'soap', 'sockets', 'sysvmsg', 'sysvsem', 'sysvshm', 'tidy', 'wddx', 'xmlrpc', 'xsl', 'zip',
     'xdebug', 'amqp', 'igbinary', 'memcached', 'mongodb', 'redis', 'apcu', 'yaml', 'weakref'
@@ -45,6 +49,17 @@ function enableExtension(string $extensionName): bool {
 
     file_put_contents('php://stderr', 'Invalid environment variable value found for '.$envName.'. Value: "'.$env.'". Valid values are "0", "1", "yes", "no", "true", "false", "on", "off".'."\n");
     exit(1);
+}
+
+foreach ($compiledExtensions as $phpExtension) {
+    $envName = 'PHP_EXTENSION_'.strtoupper($phpExtension);
+
+    $env = strtolower(trim(getenv($envName)));
+
+    if ($env === '0' || $env === 'false' || $env === 'no' || $env === 'off') {
+        file_put_contents('php://stderr', "You cannot disable extension '$phpExtension'. It is compiled in the PHP binary.\n");
+        exit(1);
+    }
 }
 
 // Validate the content of PHP_EXTENSIONS


### PR DESCRIPTION
mbstring, ftp and mysqlnd are compiled in PHP and need to be treated accordingly.

See #29 