### PR TITLE
Installing Blackfire

### DIFF
--- a/Dockerfile.apache
+++ b/Dockerfile.apache
@@ -87,6 +87,12 @@ RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && mv /tmp/blackfire/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
     && rm -rf /tmp/blackfire /tmp/blackfire-probe.tar.gz
 
+# Install Blackfire CLI tool
+RUN mkdir -p /tmp/blackfire \
+    && curl -A "Docker" -L https://blackfire.io/api/v1/releases/client/linux_static/amd64 | tar zxp -C /tmp/blackfire \
+    && mv /tmp/blackfire/blackfire /usr/bin/blackfire \
+    && rm -Rf /tmp/blackfire
+
 # |--------------------------------------------------------------------------
 # | Supercronic
 # |--------------------------------------------------------------------------

--- a/Dockerfile.apache
+++ b/Dockerfile.apache
@@ -79,6 +79,14 @@ RUN buildDeps=" \
     && echo 'extension=zip.so' > /usr/local/etc/php/conf.d/generated_conf.ini
 # Comments: MCrypt is deprecated and usage is generally discouraged. Provided here for legacy apps only.
 
+# Install Blackfire
+RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
+    && curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/linux/amd64/$version \
+    && mkdir -p /tmp/blackfire \
+    && tar zxpf /tmp/blackfire-probe.tar.gz -C /tmp/blackfire \
+    && mv /tmp/blackfire/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
+    && rm -rf /tmp/blackfire /tmp/blackfire-probe.tar.gz
+
 # |--------------------------------------------------------------------------
 # | Supercronic
 # |--------------------------------------------------------------------------

--- a/Dockerfile.apache.node10
+++ b/Dockerfile.apache.node10
@@ -87,6 +87,12 @@ RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && mv /tmp/blackfire/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
     && rm -rf /tmp/blackfire /tmp/blackfire-probe.tar.gz
 
+# Install Blackfire CLI tool
+RUN mkdir -p /tmp/blackfire \
+    && curl -A "Docker" -L https://blackfire.io/api/v1/releases/client/linux_static/amd64 | tar zxp -C /tmp/blackfire \
+    && mv /tmp/blackfire/blackfire /usr/bin/blackfire \
+    && rm -Rf /tmp/blackfire
+
 # |--------------------------------------------------------------------------
 # | Supercronic
 # |--------------------------------------------------------------------------

--- a/Dockerfile.apache.node10
+++ b/Dockerfile.apache.node10
@@ -79,6 +79,14 @@ RUN buildDeps=" \
     && echo 'extension=zip.so' > /usr/local/etc/php/conf.d/generated_conf.ini
 # Comments: MCrypt is deprecated and usage is generally discouraged. Provided here for legacy apps only.
 
+# Install Blackfire
+RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
+    && curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/linux/amd64/$version \
+    && mkdir -p /tmp/blackfire \
+    && tar zxpf /tmp/blackfire-probe.tar.gz -C /tmp/blackfire \
+    && mv /tmp/blackfire/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
+    && rm -rf /tmp/blackfire /tmp/blackfire-probe.tar.gz
+
 # |--------------------------------------------------------------------------
 # | Supercronic
 # |--------------------------------------------------------------------------

--- a/Dockerfile.apache.node6
+++ b/Dockerfile.apache.node6
@@ -87,6 +87,12 @@ RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && mv /tmp/blackfire/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
     && rm -rf /tmp/blackfire /tmp/blackfire-probe.tar.gz
 
+# Install Blackfire CLI tool
+RUN mkdir -p /tmp/blackfire \
+    && curl -A "Docker" -L https://blackfire.io/api/v1/releases/client/linux_static/amd64 | tar zxp -C /tmp/blackfire \
+    && mv /tmp/blackfire/blackfire /usr/bin/blackfire \
+    && rm -Rf /tmp/blackfire
+
 # |--------------------------------------------------------------------------
 # | Supercronic
 # |--------------------------------------------------------------------------

--- a/Dockerfile.apache.node6
+++ b/Dockerfile.apache.node6
@@ -79,6 +79,14 @@ RUN buildDeps=" \
     && echo 'extension=zip.so' > /usr/local/etc/php/conf.d/generated_conf.ini
 # Comments: MCrypt is deprecated and usage is generally discouraged. Provided here for legacy apps only.
 
+# Install Blackfire
+RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
+    && curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/linux/amd64/$version \
+    && mkdir -p /tmp/blackfire \
+    && tar zxpf /tmp/blackfire-probe.tar.gz -C /tmp/blackfire \
+    && mv /tmp/blackfire/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
+    && rm -rf /tmp/blackfire /tmp/blackfire-probe.tar.gz
+
 # |--------------------------------------------------------------------------
 # | Supercronic
 # |--------------------------------------------------------------------------

--- a/Dockerfile.apache.node8
+++ b/Dockerfile.apache.node8
@@ -87,6 +87,12 @@ RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && mv /tmp/blackfire/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
     && rm -rf /tmp/blackfire /tmp/blackfire-probe.tar.gz
 
+# Install Blackfire CLI tool
+RUN mkdir -p /tmp/blackfire \
+    && curl -A "Docker" -L https://blackfire.io/api/v1/releases/client/linux_static/amd64 | tar zxp -C /tmp/blackfire \
+    && mv /tmp/blackfire/blackfire /usr/bin/blackfire \
+    && rm -Rf /tmp/blackfire
+
 # |--------------------------------------------------------------------------
 # | Supercronic
 # |--------------------------------------------------------------------------

--- a/Dockerfile.apache.node8
+++ b/Dockerfile.apache.node8
@@ -79,6 +79,14 @@ RUN buildDeps=" \
     && echo 'extension=zip.so' > /usr/local/etc/php/conf.d/generated_conf.ini
 # Comments: MCrypt is deprecated and usage is generally discouraged. Provided here for legacy apps only.
 
+# Install Blackfire
+RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
+    && curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/linux/amd64/$version \
+    && mkdir -p /tmp/blackfire \
+    && tar zxpf /tmp/blackfire-probe.tar.gz -C /tmp/blackfire \
+    && mv /tmp/blackfire/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
+    && rm -rf /tmp/blackfire /tmp/blackfire-probe.tar.gz
+
 # |--------------------------------------------------------------------------
 # | Supercronic
 # |--------------------------------------------------------------------------

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -87,6 +87,12 @@ RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && mv /tmp/blackfire/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
     && rm -rf /tmp/blackfire /tmp/blackfire-probe.tar.gz
 
+# Install Blackfire CLI tool
+RUN mkdir -p /tmp/blackfire \
+    && curl -A "Docker" -L https://blackfire.io/api/v1/releases/client/linux_static/amd64 | tar zxp -C /tmp/blackfire \
+    && mv /tmp/blackfire/blackfire /usr/bin/blackfire \
+    && rm -Rf /tmp/blackfire
+
 # |--------------------------------------------------------------------------
 # | Supercronic
 # |--------------------------------------------------------------------------

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -79,6 +79,14 @@ RUN buildDeps=" \
     && echo 'extension=zip.so' > /usr/local/etc/php/conf.d/generated_conf.ini
 # Comments: MCrypt is deprecated and usage is generally discouraged. Provided here for legacy apps only.
 
+# Install Blackfire
+RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
+    && curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/linux/amd64/$version \
+    && mkdir -p /tmp/blackfire \
+    && tar zxpf /tmp/blackfire-probe.tar.gz -C /tmp/blackfire \
+    && mv /tmp/blackfire/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
+    && rm -rf /tmp/blackfire /tmp/blackfire-probe.tar.gz
+
 # |--------------------------------------------------------------------------
 # | Supercronic
 # |--------------------------------------------------------------------------

--- a/Dockerfile.cli.node10
+++ b/Dockerfile.cli.node10
@@ -87,6 +87,12 @@ RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && mv /tmp/blackfire/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
     && rm -rf /tmp/blackfire /tmp/blackfire-probe.tar.gz
 
+# Install Blackfire CLI tool
+RUN mkdir -p /tmp/blackfire \
+    && curl -A "Docker" -L https://blackfire.io/api/v1/releases/client/linux_static/amd64 | tar zxp -C /tmp/blackfire \
+    && mv /tmp/blackfire/blackfire /usr/bin/blackfire \
+    && rm -Rf /tmp/blackfire
+
 # |--------------------------------------------------------------------------
 # | Supercronic
 # |--------------------------------------------------------------------------

--- a/Dockerfile.cli.node10
+++ b/Dockerfile.cli.node10
@@ -79,6 +79,14 @@ RUN buildDeps=" \
     && echo 'extension=zip.so' > /usr/local/etc/php/conf.d/generated_conf.ini
 # Comments: MCrypt is deprecated and usage is generally discouraged. Provided here for legacy apps only.
 
+# Install Blackfire
+RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
+    && curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/linux/amd64/$version \
+    && mkdir -p /tmp/blackfire \
+    && tar zxpf /tmp/blackfire-probe.tar.gz -C /tmp/blackfire \
+    && mv /tmp/blackfire/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
+    && rm -rf /tmp/blackfire /tmp/blackfire-probe.tar.gz
+
 # |--------------------------------------------------------------------------
 # | Supercronic
 # |--------------------------------------------------------------------------

--- a/Dockerfile.cli.node6
+++ b/Dockerfile.cli.node6
@@ -87,6 +87,12 @@ RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && mv /tmp/blackfire/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
     && rm -rf /tmp/blackfire /tmp/blackfire-probe.tar.gz
 
+# Install Blackfire CLI tool
+RUN mkdir -p /tmp/blackfire \
+    && curl -A "Docker" -L https://blackfire.io/api/v1/releases/client/linux_static/amd64 | tar zxp -C /tmp/blackfire \
+    && mv /tmp/blackfire/blackfire /usr/bin/blackfire \
+    && rm -Rf /tmp/blackfire
+
 # |--------------------------------------------------------------------------
 # | Supercronic
 # |--------------------------------------------------------------------------

--- a/Dockerfile.cli.node6
+++ b/Dockerfile.cli.node6
@@ -79,6 +79,14 @@ RUN buildDeps=" \
     && echo 'extension=zip.so' > /usr/local/etc/php/conf.d/generated_conf.ini
 # Comments: MCrypt is deprecated and usage is generally discouraged. Provided here for legacy apps only.
 
+# Install Blackfire
+RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
+    && curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/linux/amd64/$version \
+    && mkdir -p /tmp/blackfire \
+    && tar zxpf /tmp/blackfire-probe.tar.gz -C /tmp/blackfire \
+    && mv /tmp/blackfire/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
+    && rm -rf /tmp/blackfire /tmp/blackfire-probe.tar.gz
+
 # |--------------------------------------------------------------------------
 # | Supercronic
 # |--------------------------------------------------------------------------

--- a/Dockerfile.cli.node8
+++ b/Dockerfile.cli.node8
@@ -87,6 +87,12 @@ RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && mv /tmp/blackfire/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
     && rm -rf /tmp/blackfire /tmp/blackfire-probe.tar.gz
 
+# Install Blackfire CLI tool
+RUN mkdir -p /tmp/blackfire \
+    && curl -A "Docker" -L https://blackfire.io/api/v1/releases/client/linux_static/amd64 | tar zxp -C /tmp/blackfire \
+    && mv /tmp/blackfire/blackfire /usr/bin/blackfire \
+    && rm -Rf /tmp/blackfire
+
 # |--------------------------------------------------------------------------
 # | Supercronic
 # |--------------------------------------------------------------------------

--- a/Dockerfile.cli.node8
+++ b/Dockerfile.cli.node8
@@ -79,6 +79,14 @@ RUN buildDeps=" \
     && echo 'extension=zip.so' > /usr/local/etc/php/conf.d/generated_conf.ini
 # Comments: MCrypt is deprecated and usage is generally discouraged. Provided here for legacy apps only.
 
+# Install Blackfire
+RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
+    && curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/linux/amd64/$version \
+    && mkdir -p /tmp/blackfire \
+    && tar zxpf /tmp/blackfire-probe.tar.gz -C /tmp/blackfire \
+    && mv /tmp/blackfire/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
+    && rm -rf /tmp/blackfire /tmp/blackfire-probe.tar.gz
+
 # |--------------------------------------------------------------------------
 # | Supercronic
 # |--------------------------------------------------------------------------

--- a/Dockerfile.fpm
+++ b/Dockerfile.fpm
@@ -87,6 +87,12 @@ RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && mv /tmp/blackfire/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
     && rm -rf /tmp/blackfire /tmp/blackfire-probe.tar.gz
 
+# Install Blackfire CLI tool
+RUN mkdir -p /tmp/blackfire \
+    && curl -A "Docker" -L https://blackfire.io/api/v1/releases/client/linux_static/amd64 | tar zxp -C /tmp/blackfire \
+    && mv /tmp/blackfire/blackfire /usr/bin/blackfire \
+    && rm -Rf /tmp/blackfire
+
 # |--------------------------------------------------------------------------
 # | Supercronic
 # |--------------------------------------------------------------------------

--- a/Dockerfile.fpm
+++ b/Dockerfile.fpm
@@ -79,6 +79,14 @@ RUN buildDeps=" \
     && echo 'extension=zip.so' > /usr/local/etc/php/conf.d/generated_conf.ini
 # Comments: MCrypt is deprecated and usage is generally discouraged. Provided here for legacy apps only.
 
+# Install Blackfire
+RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
+    && curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/linux/amd64/$version \
+    && mkdir -p /tmp/blackfire \
+    && tar zxpf /tmp/blackfire-probe.tar.gz -C /tmp/blackfire \
+    && mv /tmp/blackfire/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
+    && rm -rf /tmp/blackfire /tmp/blackfire-probe.tar.gz
+
 # |--------------------------------------------------------------------------
 # | Supercronic
 # |--------------------------------------------------------------------------

--- a/Dockerfile.fpm.node10
+++ b/Dockerfile.fpm.node10
@@ -87,6 +87,12 @@ RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && mv /tmp/blackfire/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
     && rm -rf /tmp/blackfire /tmp/blackfire-probe.tar.gz
 
+# Install Blackfire CLI tool
+RUN mkdir -p /tmp/blackfire \
+    && curl -A "Docker" -L https://blackfire.io/api/v1/releases/client/linux_static/amd64 | tar zxp -C /tmp/blackfire \
+    && mv /tmp/blackfire/blackfire /usr/bin/blackfire \
+    && rm -Rf /tmp/blackfire
+
 # |--------------------------------------------------------------------------
 # | Supercronic
 # |--------------------------------------------------------------------------

--- a/Dockerfile.fpm.node10
+++ b/Dockerfile.fpm.node10
@@ -79,6 +79,14 @@ RUN buildDeps=" \
     && echo 'extension=zip.so' > /usr/local/etc/php/conf.d/generated_conf.ini
 # Comments: MCrypt is deprecated and usage is generally discouraged. Provided here for legacy apps only.
 
+# Install Blackfire
+RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
+    && curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/linux/amd64/$version \
+    && mkdir -p /tmp/blackfire \
+    && tar zxpf /tmp/blackfire-probe.tar.gz -C /tmp/blackfire \
+    && mv /tmp/blackfire/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
+    && rm -rf /tmp/blackfire /tmp/blackfire-probe.tar.gz
+
 # |--------------------------------------------------------------------------
 # | Supercronic
 # |--------------------------------------------------------------------------

--- a/Dockerfile.fpm.node6
+++ b/Dockerfile.fpm.node6
@@ -87,6 +87,12 @@ RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && mv /tmp/blackfire/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
     && rm -rf /tmp/blackfire /tmp/blackfire-probe.tar.gz
 
+# Install Blackfire CLI tool
+RUN mkdir -p /tmp/blackfire \
+    && curl -A "Docker" -L https://blackfire.io/api/v1/releases/client/linux_static/amd64 | tar zxp -C /tmp/blackfire \
+    && mv /tmp/blackfire/blackfire /usr/bin/blackfire \
+    && rm -Rf /tmp/blackfire
+
 # |--------------------------------------------------------------------------
 # | Supercronic
 # |--------------------------------------------------------------------------

--- a/Dockerfile.fpm.node6
+++ b/Dockerfile.fpm.node6
@@ -79,6 +79,14 @@ RUN buildDeps=" \
     && echo 'extension=zip.so' > /usr/local/etc/php/conf.d/generated_conf.ini
 # Comments: MCrypt is deprecated and usage is generally discouraged. Provided here for legacy apps only.
 
+# Install Blackfire
+RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
+    && curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/linux/amd64/$version \
+    && mkdir -p /tmp/blackfire \
+    && tar zxpf /tmp/blackfire-probe.tar.gz -C /tmp/blackfire \
+    && mv /tmp/blackfire/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
+    && rm -rf /tmp/blackfire /tmp/blackfire-probe.tar.gz
+
 # |--------------------------------------------------------------------------
 # | Supercronic
 # |--------------------------------------------------------------------------

--- a/Dockerfile.fpm.node8
+++ b/Dockerfile.fpm.node8
@@ -87,6 +87,12 @@ RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && mv /tmp/blackfire/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
     && rm -rf /tmp/blackfire /tmp/blackfire-probe.tar.gz
 
+# Install Blackfire CLI tool
+RUN mkdir -p /tmp/blackfire \
+    && curl -A "Docker" -L https://blackfire.io/api/v1/releases/client/linux_static/amd64 | tar zxp -C /tmp/blackfire \
+    && mv /tmp/blackfire/blackfire /usr/bin/blackfire \
+    && rm -Rf /tmp/blackfire
+
 # |--------------------------------------------------------------------------
 # | Supercronic
 # |--------------------------------------------------------------------------

--- a/Dockerfile.fpm.node8
+++ b/Dockerfile.fpm.node8
@@ -79,6 +79,14 @@ RUN buildDeps=" \
     && echo 'extension=zip.so' > /usr/local/etc/php/conf.d/generated_conf.ini
 # Comments: MCrypt is deprecated and usage is generally discouraged. Provided here for legacy apps only.
 
+# Install Blackfire
+RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
+    && curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/linux/amd64/$version \
+    && mkdir -p /tmp/blackfire \
+    && tar zxpf /tmp/blackfire-probe.tar.gz -C /tmp/blackfire \
+    && mv /tmp/blackfire/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
+    && rm -rf /tmp/blackfire /tmp/blackfire-probe.tar.gz
+
 # |--------------------------------------------------------------------------
 # | Supercronic
 # |--------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Below is a list of extensions available in this image:
 
 **Enabled by default:** apcu mysqli opcache pdo pdo_mysql redis zip soap
 
-**Available (can be enabled using environment variables):** amqp ast bcmath bz2 calendar dba enchant ev event exif gd gettext gmp igbinary imap intl ldap mcrypt memcached mongodb pcntl pdo_dblib pdo_pgsql pgsql pspell shmop snmp sockets sysvmsg sysvsem sysvshm tidy wddx weakref(-beta) xdebug xmlrpc xsl yaml
+**Available (can be enabled using environment variables):** amqp ast bcmath blackfire bz2 calendar dba enchant ev event exif gd gettext gmp igbinary imap intl ldap mcrypt memcached mongodb pcntl pdo_dblib pdo_pgsql pgsql pspell shmop snmp sockets sysvmsg sysvsem sysvshm tidy wddx weakref(-beta) xdebug xmlrpc xsl yaml
 
 ## Enabling/disabling extensions
 
@@ -419,6 +419,60 @@ spec:
     image: thecodingmachine/php:7.2-v1-apache
     securityContext:
       allowPrivilegeEscalation: true # never use "false" here.
+```
+
+## Profiling with Blackfire
+
+This image comes with the Blackfire PHP probe. You can install it using:
+
+```bash
+PHP_EXTENSION_BLACKFIRE=1
+```
+
+By default, the image expects that the blackfire agent is started in another container.
+
+Your `docker-compose.yml` file will typically look like this:
+
+**docker-compose.yml**
+```yml
+version: '3.3'
+services:
+  php:
+    image: thecodingmachine/php:7.2-v1-apache
+    ports:
+      - "80:80"
+    environment:
+      PHP_EXTENSION_BLACKFIRE: 1
+  blackfire:
+    image: blackfire/blackfire
+    environment:
+        # Exposes the host BLACKFIRE_SERVER_ID and TOKEN environment variables.
+        - BLACKFIRE_SERVER_ID
+        - BLACKFIRE_SERVER_TOKEN
+        # You can also use global environment credentials :
+        # BLACKFIRE_SERVER_ID: SERVER-ID
+        # BLACKFIRE_SERVER_TOKEN: SERVER-TOKEN
+```
+
+See [Blackfire Docker documentation](https://blackfire.io/docs/integrations/docker#running-the-agent) for more information.
+
+The image assumes that the Blackfire agent is accessible via the `blackfire` URL (like in the exemple above).
+If for some reason, the container name is not "blackfire", you can customize the agent URL with the `BLACKFIRE_AGENT` environment variable:
+
+**docker-compose.yml**
+```yml
+version: '3.3'
+services:
+  php:
+    image: thecodingmachine/php:7.2-v1-apache
+    environment:
+      PHP_EXTENSION_BLACKFIRE: 1
+      BLACKFIRE_AGENT: myblackfire
+    # ...
+  myblackfire:
+    image: blackfire/blackfire
+    environment:
+        # ...
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ spec:
 
 ## Profiling with Blackfire
 
-This image comes with the Blackfire PHP probe. You can install it using:
+This image comes with the [Blackfire]() PHP probe. You can install it using:
 
 ```bash
 PHP_EXTENSION_BLACKFIRE=1

--- a/build-and-test.sh
+++ b/build-and-test.sh
@@ -33,6 +33,13 @@ set -e
 # Let's check that the "xdebug.remote_host" contains a value different from "no value"
 docker run --rm -e PHP_EXTENSION_XDEBUG=1 thecodingmachine/php:${BRANCH}-${BRANCH_VARIANT} php -i | grep xdebug.remote_host| grep -v "no value"
 
+# Tests that blackfire + xdebug will output an error
+RESULT=`docker run -e PHP_EXTENSION_XDEBUG=1 -e PHP_EXTENSION_BLACKFIRE=1 thecodingmachine/php:${BRANCH}-${BRANCH_VARIANT} php -v 2>&1 | grep 'WARNING: Both Blackfire and Xdebug are enabled. This is not recommended as the PHP engine may not behave as expected. You should strongly consider disabling Xdebug or Blackfire.'`
+[[ "$RESULT" = "WARNING: Both Blackfire and Xdebug are enabled. This is not recommended as the PHP engine may not behave as expected. You should strongly consider disabling Xdebug or Blackfire." ]]
+
+# Check that blackfire can be enabled
+docker run --rm -e PHP_EXTENSION_BLACKFIRE=1 thecodingmachine/php:${BRANCH}-${BRANCH_VARIANT} php -m | grep blackfire
+
 if [[ $VARIANT == apache* ]]; then
     # Test if environment variables are passed to PHP
     DOCKER_CID=`docker run --rm -e MYVAR=foo -p "81:80" -d -v $(pwd):/var/www/html thecodingmachine/php:${BRANCH}-${BRANCH_VARIANT}`

--- a/images.yml
+++ b/images.yml
@@ -2,4 +2,4 @@ php_version: 7.2
 xdebug_version: 2.6.0
 compiled_php_extensions: mbstring ftp mysqlnd
 enabled_php_extensions: apcu mysqli opcache pdo pdo_mysql redis zip soap
-disabled_php_extensions: amqp ast bcmath bz2 calendar dba enchant ev event exif gd gettext gmp igbinary imap intl ldap mcrypt memcached mongodb pcntl pdo_dblib pdo_pgsql pgsql pspell shmop snmp sockets sysvmsg sysvsem sysvshm tidy wddx weakref(-beta) xdebug xmlrpc xsl yaml
+disabled_php_extensions: amqp ast bcmath blackfire bz2 calendar dba enchant ev event exif gd gettext gmp igbinary imap intl ldap mcrypt memcached mongodb pcntl pdo_dblib pdo_pgsql pgsql pspell shmop snmp sockets sysvmsg sysvsem sysvshm tidy wddx weakref(-beta) xdebug xmlrpc xsl yaml

--- a/utils/Dockerfile.blueprint
+++ b/utils/Dockerfile.blueprint
@@ -83,6 +83,14 @@ RUN buildDeps=" \
     && echo 'extension=zip.so' > /usr/local/etc/php/conf.d/generated_conf.ini
 # Comments: MCrypt is deprecated and usage is generally discouraged. Provided here for legacy apps only.
 
+# Install Blackfire
+RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
+    && curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/linux/amd64/$version \
+    && mkdir -p /tmp/blackfire \
+    && tar zxpf /tmp/blackfire-probe.tar.gz -C /tmp/blackfire \
+    && mv /tmp/blackfire/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
+    && rm -rf /tmp/blackfire /tmp/blackfire-probe.tar.gz
+
 # |--------------------------------------------------------------------------
 # | Supercronic
 # |--------------------------------------------------------------------------

--- a/utils/Dockerfile.blueprint
+++ b/utils/Dockerfile.blueprint
@@ -91,6 +91,12 @@ RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && mv /tmp/blackfire/blackfire-*.so $(php -r "echo ini_get('extension_dir');")/blackfire.so \
     && rm -rf /tmp/blackfire /tmp/blackfire-probe.tar.gz
 
+# Install Blackfire CLI tool
+RUN mkdir -p /tmp/blackfire \
+    && curl -A "Docker" -L https://blackfire.io/api/v1/releases/client/linux_static/amd64 | tar zxp -C /tmp/blackfire \
+    && mv /tmp/blackfire/blackfire /usr/bin/blackfire \
+    && rm -Rf /tmp/blackfire
+
 # |--------------------------------------------------------------------------
 # | Supercronic
 # |--------------------------------------------------------------------------

--- a/utils/README.blueprint.md
+++ b/utils/README.blueprint.md
@@ -409,6 +409,60 @@ spec:
       allowPrivilegeEscalation: true # never use "false" here.
 ```
 
+## Profiling with Blackfire
+
+This image comes with the [Blackfire]() PHP probe. You can install it using:
+
+```bash
+PHP_EXTENSION_BLACKFIRE=1
+```
+
+By default, the image expects that the blackfire agent is started in another container.
+
+Your `docker-compose.yml` file will typically look like this:
+
+**docker-compose.yml**
+```yml
+version: '3.3'
+services:
+  php:
+    image: thecodingmachine/php:{{ $image.php_version }}-v1-apache
+    ports:
+      - "80:80"
+    environment:
+      PHP_EXTENSION_BLACKFIRE: 1
+  blackfire:
+    image: blackfire/blackfire
+    environment:
+        # Exposes the host BLACKFIRE_SERVER_ID and TOKEN environment variables.
+        - BLACKFIRE_SERVER_ID
+        - BLACKFIRE_SERVER_TOKEN
+        # You can also use global environment credentials :
+        # BLACKFIRE_SERVER_ID: SERVER-ID
+        # BLACKFIRE_SERVER_TOKEN: SERVER-TOKEN
+```
+
+See [Blackfire Docker documentation](https://blackfire.io/docs/integrations/docker#running-the-agent) for more information.
+
+The image assumes that the Blackfire agent is accessible via the `blackfire` URL (like in the exemple above).
+If for some reason, the container name is not "blackfire", you can customize the agent URL with the `BLACKFIRE_AGENT` environment variable:
+
+**docker-compose.yml**
+```yml
+version: '3.3'
+services:
+  php:
+    image: thecodingmachine/php:{{ $image.php_version }}-v1-apache
+    environment:
+      PHP_EXTENSION_BLACKFIRE: 1
+      BLACKFIRE_AGENT: myblackfire
+    # ...
+  myblackfire:
+    image: blackfire/blackfire
+    environment:
+        # ...
+```
+
 ## Contributing
 
 There is one branch per minor PHP version and version of the image.

--- a/utils/generate_conf.php
+++ b/utils/generate_conf.php
@@ -12,7 +12,7 @@ $availableExtensions = [
     'ast', 'bcmath', 'bz2', 'calendar', 'dba', 'enchant', 'ev', 'event', 'exif', 'gd', 'gettext', 'gmp', 'imap', 'intl', 'ldap',
     'mcrypt', 'mysqli', 'opcache', 'pcntl', 'pdo_dblib', 'pdo_mysql', 'pdo_pgsql', 'pgsql', 'pspell',
     'shmop', 'snmp', 'soap', 'sockets', 'sysvmsg', 'sysvsem', 'sysvshm', 'tidy', 'wddx', 'xmlrpc', 'xsl', 'zip',
-    'xdebug', 'amqp', 'igbinary', 'memcached', 'mongodb', 'redis', 'apcu', 'yaml', 'weakref'
+    'xdebug', 'amqp', 'igbinary', 'memcached', 'mongodb', 'redis', 'apcu', 'yaml', 'weakref', 'blackfire'
 ];
 
 $delimiter = [',', '|', ';', ':'];
@@ -70,6 +70,10 @@ foreach ($phpExtensions as $phpExtension) {
     }
 }
 
+if (enableExtension('xdebug') && enableExtension('blackfire')) {
+    error_log('WARNING: Both Blackfire and Xdebug are enabled. This is not recommended as the PHP engine may not behave as expected. You should strongly consider disabling Xdebug or Blackfire.');
+}
+
 foreach ($availableExtensions as $extension) {
     if (enableExtension($extension)) {
         if ($extension === 'xdebug') {
@@ -79,6 +83,13 @@ foreach ($availableExtensions as $extension) {
             //echo "xdebug.remote_autostart=off\n";
             //echo "xdebug.remote_port=9000\n";
             //echo "xdebug.remote_connect_back=0\n";
+        } elseif ($extension === 'blackfire') {
+            $blackFireAgent = getenv('BLACKFIRE_AGENT');
+            if (!$blackFireAgent) {
+                $blackFireAgent = 'blackfire';
+            }
+            echo "extension=blackfire.so\n";
+            echo "blackfire.agent_socket=tcp://$blackFireAgent:8707\n";
         } elseif ($extension === 'opcache') {
             echo "zend_extension=opcache.so\n";
         } else {


### PR DESCRIPTION
As proposed by @mnapoli in #60 , this PR installs the Blackfire extension.

> That would be awesome if Blackfire was preinstalled in the Docker images. That would allow to profile PHP scripts very easily.
>
> To make that happen the following needs to be done in the Docker images:
> 
> - install the PHP extension: https://blackfire.io/docs/integrations/docker#enabling-the-php-probe
> - install the Blackfire CLI tool in the image too (to profile PHP scripts): https://blackfire.io/docs/integrations/docker#using-the-client-for-cli-profiling
>
> Users **not** using Blackfire should not be impacted because the extension will not do anything. (it could also be possible to make the extension opt-in through an environment variable, that would be even cleaner)
>
> Users using Blackfire will need to:
> 
> - run the agent, e.g. through Docker-Compose: https://blackfire.io/docs/integrations/docker#running-the-agent
> - define environment variables with their credentials (https://blackfire.io/docs/integrations/docker)
> - install the browser extension (https://blackfire.io/docs/up-and-running/installation)

The Blackfire extension can be enabled using the `PHP_EXTENSION_XDEBUG` environment variable.

If Xebug and Blackfire are enabled at the same time, a Warning will be issued on container startup.

The blackfire agent URL is customizable via the `BLACKFIRE_AGENT` environment variable.

The Blackfire CLI is also installed out of the box in the image.