### PR TITLE
Making cron optionnal in Slim image

### DIFF
--- a/Dockerfile.7.1.apache
+++ b/Dockerfile.7.1.apache
@@ -1,3 +1,5 @@
+ARG INSTALL_CRON=1
+ARG INSTALL_COMPOSER=1
 FROM thecodingmachine/php:7.1-v2-slim-apache
 
 LABEL authors="Julien Neuhart <j.neuhart@thecodingmachine.com>, David Négrier <d.negrier@thecodingmachine.com>"

--- a/Dockerfile.7.1.cli
+++ b/Dockerfile.7.1.cli
@@ -1,3 +1,5 @@
+ARG INSTALL_CRON=1
+ARG INSTALL_COMPOSER=1
 FROM thecodingmachine/php:7.1-v2-slim-cli
 
 LABEL authors="Julien Neuhart <j.neuhart@thecodingmachine.com>, David Négrier <d.negrier@thecodingmachine.com>"

--- a/Dockerfile.7.1.fpm
+++ b/Dockerfile.7.1.fpm
@@ -1,3 +1,5 @@
+ARG INSTALL_CRON=1
+ARG INSTALL_COMPOSER=1
 FROM thecodingmachine/php:7.1-v2-slim-fpm
 
 LABEL authors="Julien Neuhart <j.neuhart@thecodingmachine.com>, David Négrier <d.negrier@thecodingmachine.com>"

--- a/Dockerfile.7.1.slim.apache
+++ b/Dockerfile.7.1.slim.apache
@@ -18,23 +18,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends git nano sudo i
 RUN cd /usr/local/lib/thecodingmachine-php/extensions/current/zip && ./install.sh
 # RUN echo 'extension=zip.so' > /usr/local/etc/php/conf.d/generated_conf.ini
 
-
-# |--------------------------------------------------------------------------
-# | Supercronic
-# |--------------------------------------------------------------------------
-# |
-# | Supercronic is a drop-in replacement for cron (for containers).
-# |
-
-RUN SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.1.5/supercronic-linux-amd64 \
- && SUPERCRONIC=supercronic-linux-amd64 \
- && SUPERCRONIC_SHA1SUM=9aeb41e00cc7b71d30d33c57a2333f2c2581a201 \
- && curl -fsSLO "$SUPERCRONIC_URL" \
- && echo "${SUPERCRONIC_SHA1SUM}  ${SUPERCRONIC}" | sha1sum -c - \
- && chmod +x "$SUPERCRONIC" \
- && mv "$SUPERCRONIC" "/usr/local/bin/${SUPERCRONIC}" \
- && ln -s "/usr/local/bin/${SUPERCRONIC}" /usr/local/bin/supercronic
-
 # |--------------------------------------------------------------------------
 # | User
 # |--------------------------------------------------------------------------
@@ -84,7 +67,10 @@ COPY utils/generate_conf.php /usr/local/bin/generate_conf.php
 # |
 
 USER docker
-RUN composer global require hirak/prestissimo
+RUN composer global require hirak/prestissimo && \
+    composer global require bamarni/symfony-console-autocomplete && \
+    rm -rf $HOME\.composer
+
 USER root
 
 
@@ -135,8 +121,6 @@ RUN mkdir ~/.ssh && touch ~/.ssh/known_hosts && chmod 644 ~/.ssh/known_hosts && 
 # |
 # | Let's update the .bashrc to add nice aliases
 # |
-
-RUN composer global require bamarni/symfony-console-autocomplete
 
 RUN echo 'eval "$(symfony-autocomplete)"' > ~/.bash_profile
 
@@ -213,6 +197,26 @@ COPY utils/install_selected_extensions.php /usr/local/bin/install_selected_exten
 ONBUILD ARG PHP_EXTENSIONS
 ONBUILD ENV PHP_EXTENSIONS="$PHP_EXTENSIONS"
 ONBUILD RUN sudo PHP_EXTENSIONS="$PHP_EXTENSIONS" php /usr/local/bin/install_selected_extensions.php
+
+# |--------------------------------------------------------------------------
+# | Supercronic
+# |--------------------------------------------------------------------------
+# |
+# | Supercronic is a drop-in replacement for cron (for containers).
+# |
+
+ONBUILD ARG INSTALL_CRON
+ONBUILD RUN if [ -n "$INSTALL_CRON" ]; then \
+ SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.1.5/supercronic-linux-amd64 \
+ && SUPERCRONIC=supercronic-linux-amd64 \
+ && SUPERCRONIC_SHA1SUM=9aeb41e00cc7b71d30d33c57a2333f2c2581a201 \
+ && curl -fsSLO "$SUPERCRONIC_URL" \
+ && echo "${SUPERCRONIC_SHA1SUM}  ${SUPERCRONIC}" | sha1sum -c - \
+ && chmod +x "$SUPERCRONIC" \
+ && sudo mv "$SUPERCRONIC" "/usr/local/bin/${SUPERCRONIC}" \
+ && sudo ln -s "/usr/local/bin/${SUPERCRONIC}" /usr/local/bin/supercronic; \
+ fi;
+
 
 # |--------------------------------------------------------------------------
 # | NodeJS

--- a/Dockerfile.7.1.slim.cli
+++ b/Dockerfile.7.1.slim.cli
@@ -18,23 +18,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends git nano sudo i
 RUN cd /usr/local/lib/thecodingmachine-php/extensions/current/zip && ./install.sh
 # RUN echo 'extension=zip.so' > /usr/local/etc/php/conf.d/generated_conf.ini
 
-
-# |--------------------------------------------------------------------------
-# | Supercronic
-# |--------------------------------------------------------------------------
-# |
-# | Supercronic is a drop-in replacement for cron (for containers).
-# |
-
-RUN SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.1.5/supercronic-linux-amd64 \
- && SUPERCRONIC=supercronic-linux-amd64 \
- && SUPERCRONIC_SHA1SUM=9aeb41e00cc7b71d30d33c57a2333f2c2581a201 \
- && curl -fsSLO "$SUPERCRONIC_URL" \
- && echo "${SUPERCRONIC_SHA1SUM}  ${SUPERCRONIC}" | sha1sum -c - \
- && chmod +x "$SUPERCRONIC" \
- && mv "$SUPERCRONIC" "/usr/local/bin/${SUPERCRONIC}" \
- && ln -s "/usr/local/bin/${SUPERCRONIC}" /usr/local/bin/supercronic
-
 # |--------------------------------------------------------------------------
 # | User
 # |--------------------------------------------------------------------------
@@ -84,7 +67,10 @@ COPY utils/generate_conf.php /usr/local/bin/generate_conf.php
 # |
 
 USER docker
-RUN composer global require hirak/prestissimo
+RUN composer global require hirak/prestissimo && \
+    composer global require bamarni/symfony-console-autocomplete && \
+    rm -rf $HOME\.composer
+
 USER root
 
 
@@ -122,8 +108,6 @@ RUN mkdir ~/.ssh && touch ~/.ssh/known_hosts && chmod 644 ~/.ssh/known_hosts && 
 # |
 # | Let's update the .bashrc to add nice aliases
 # |
-
-RUN composer global require bamarni/symfony-console-autocomplete
 
 RUN echo 'eval "$(symfony-autocomplete)"' > ~/.bash_profile
 
@@ -181,6 +165,26 @@ COPY utils/install_selected_extensions.php /usr/local/bin/install_selected_exten
 ONBUILD ARG PHP_EXTENSIONS
 ONBUILD ENV PHP_EXTENSIONS="$PHP_EXTENSIONS"
 ONBUILD RUN sudo PHP_EXTENSIONS="$PHP_EXTENSIONS" php /usr/local/bin/install_selected_extensions.php
+
+# |--------------------------------------------------------------------------
+# | Supercronic
+# |--------------------------------------------------------------------------
+# |
+# | Supercronic is a drop-in replacement for cron (for containers).
+# |
+
+ONBUILD ARG INSTALL_CRON
+ONBUILD RUN if [ -n "$INSTALL_CRON" ]; then \
+ SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.1.5/supercronic-linux-amd64 \
+ && SUPERCRONIC=supercronic-linux-amd64 \
+ && SUPERCRONIC_SHA1SUM=9aeb41e00cc7b71d30d33c57a2333f2c2581a201 \
+ && curl -fsSLO "$SUPERCRONIC_URL" \
+ && echo "${SUPERCRONIC_SHA1SUM}  ${SUPERCRONIC}" | sha1sum -c - \
+ && chmod +x "$SUPERCRONIC" \
+ && sudo mv "$SUPERCRONIC" "/usr/local/bin/${SUPERCRONIC}" \
+ && sudo ln -s "/usr/local/bin/${SUPERCRONIC}" /usr/local/bin/supercronic; \
+ fi;
+
 
 # |--------------------------------------------------------------------------
 # | NodeJS

--- a/Dockerfile.7.1.slim.fpm
+++ b/Dockerfile.7.1.slim.fpm
@@ -18,23 +18,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends git nano sudo i
 RUN cd /usr/local/lib/thecodingmachine-php/extensions/current/zip && ./install.sh
 # RUN echo 'extension=zip.so' > /usr/local/etc/php/conf.d/generated_conf.ini
 
-
-# |--------------------------------------------------------------------------
-# | Supercronic
-# |--------------------------------------------------------------------------
-# |
-# | Supercronic is a drop-in replacement for cron (for containers).
-# |
-
-RUN SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.1.5/supercronic-linux-amd64 \
- && SUPERCRONIC=supercronic-linux-amd64 \
- && SUPERCRONIC_SHA1SUM=9aeb41e00cc7b71d30d33c57a2333f2c2581a201 \
- && curl -fsSLO "$SUPERCRONIC_URL" \
- && echo "${SUPERCRONIC_SHA1SUM}  ${SUPERCRONIC}" | sha1sum -c - \
- && chmod +x "$SUPERCRONIC" \
- && mv "$SUPERCRONIC" "/usr/local/bin/${SUPERCRONIC}" \
- && ln -s "/usr/local/bin/${SUPERCRONIC}" /usr/local/bin/supercronic
-
 # |--------------------------------------------------------------------------
 # | User
 # |--------------------------------------------------------------------------
@@ -84,7 +67,10 @@ COPY utils/generate_conf.php /usr/local/bin/generate_conf.php
 # |
 
 USER docker
-RUN composer global require hirak/prestissimo
+RUN composer global require hirak/prestissimo && \
+    composer global require bamarni/symfony-console-autocomplete && \
+    rm -rf $HOME\.composer
+
 USER root
 
 
@@ -121,8 +107,6 @@ RUN mkdir ~/.ssh && touch ~/.ssh/known_hosts && chmod 644 ~/.ssh/known_hosts && 
 # |
 # | Let's update the .bashrc to add nice aliases
 # |
-
-RUN composer global require bamarni/symfony-console-autocomplete
 
 RUN echo 'eval "$(symfony-autocomplete)"' > ~/.bash_profile
 
@@ -180,6 +164,26 @@ COPY utils/install_selected_extensions.php /usr/local/bin/install_selected_exten
 ONBUILD ARG PHP_EXTENSIONS
 ONBUILD ENV PHP_EXTENSIONS="$PHP_EXTENSIONS"
 ONBUILD RUN sudo PHP_EXTENSIONS="$PHP_EXTENSIONS" php /usr/local/bin/install_selected_extensions.php
+
+# |--------------------------------------------------------------------------
+# | Supercronic
+# |--------------------------------------------------------------------------
+# |
+# | Supercronic is a drop-in replacement for cron (for containers).
+# |
+
+ONBUILD ARG INSTALL_CRON
+ONBUILD RUN if [ -n "$INSTALL_CRON" ]; then \
+ SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.1.5/supercronic-linux-amd64 \
+ && SUPERCRONIC=supercronic-linux-amd64 \
+ && SUPERCRONIC_SHA1SUM=9aeb41e00cc7b71d30d33c57a2333f2c2581a201 \
+ && curl -fsSLO "$SUPERCRONIC_URL" \
+ && echo "${SUPERCRONIC_SHA1SUM}  ${SUPERCRONIC}" | sha1sum -c - \
+ && chmod +x "$SUPERCRONIC" \
+ && sudo mv "$SUPERCRONIC" "/usr/local/bin/${SUPERCRONIC}" \
+ && sudo ln -s "/usr/local/bin/${SUPERCRONIC}" /usr/local/bin/supercronic; \
+ fi;
+
 
 # |--------------------------------------------------------------------------
 # | NodeJS

--- a/Dockerfile.7.2.apache
+++ b/Dockerfile.7.2.apache
@@ -1,3 +1,5 @@
+ARG INSTALL_CRON=1
+ARG INSTALL_COMPOSER=1
 FROM thecodingmachine/php:7.2-v2-slim-apache
 
 LABEL authors="Julien Neuhart <j.neuhart@thecodingmachine.com>, David Négrier <d.negrier@thecodingmachine.com>"

--- a/Dockerfile.7.2.cli
+++ b/Dockerfile.7.2.cli
@@ -1,3 +1,5 @@
+ARG INSTALL_CRON=1
+ARG INSTALL_COMPOSER=1
 FROM thecodingmachine/php:7.2-v2-slim-cli
 
 LABEL authors="Julien Neuhart <j.neuhart@thecodingmachine.com>, David Négrier <d.negrier@thecodingmachine.com>"

--- a/Dockerfile.7.2.fpm
+++ b/Dockerfile.7.2.fpm
@@ -1,3 +1,5 @@
+ARG INSTALL_CRON=1
+ARG INSTALL_COMPOSER=1
 FROM thecodingmachine/php:7.2-v2-slim-fpm
 
 LABEL authors="Julien Neuhart <j.neuhart@thecodingmachine.com>, David Négrier <d.negrier@thecodingmachine.com>"

--- a/Dockerfile.7.2.slim.apache
+++ b/Dockerfile.7.2.slim.apache
@@ -18,23 +18,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends git nano sudo i
 RUN cd /usr/local/lib/thecodingmachine-php/extensions/current/zip && ./install.sh
 # RUN echo 'extension=zip.so' > /usr/local/etc/php/conf.d/generated_conf.ini
 
-
-# |--------------------------------------------------------------------------
-# | Supercronic
-# |--------------------------------------------------------------------------
-# |
-# | Supercronic is a drop-in replacement for cron (for containers).
-# |
-
-RUN SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.1.5/supercronic-linux-amd64 \
- && SUPERCRONIC=supercronic-linux-amd64 \
- && SUPERCRONIC_SHA1SUM=9aeb41e00cc7b71d30d33c57a2333f2c2581a201 \
- && curl -fsSLO "$SUPERCRONIC_URL" \
- && echo "${SUPERCRONIC_SHA1SUM}  ${SUPERCRONIC}" | sha1sum -c - \
- && chmod +x "$SUPERCRONIC" \
- && mv "$SUPERCRONIC" "/usr/local/bin/${SUPERCRONIC}" \
- && ln -s "/usr/local/bin/${SUPERCRONIC}" /usr/local/bin/supercronic
-
 # |--------------------------------------------------------------------------
 # | User
 # |--------------------------------------------------------------------------
@@ -84,7 +67,10 @@ COPY utils/generate_conf.php /usr/local/bin/generate_conf.php
 # |
 
 USER docker
-RUN composer global require hirak/prestissimo
+RUN composer global require hirak/prestissimo && \
+    composer global require bamarni/symfony-console-autocomplete && \
+    rm -rf $HOME\.composer
+
 USER root
 
 
@@ -135,8 +121,6 @@ RUN mkdir ~/.ssh && touch ~/.ssh/known_hosts && chmod 644 ~/.ssh/known_hosts && 
 # |
 # | Let's update the .bashrc to add nice aliases
 # |
-
-RUN composer global require bamarni/symfony-console-autocomplete
 
 RUN echo 'eval "$(symfony-autocomplete)"' > ~/.bash_profile
 
@@ -213,6 +197,26 @@ COPY utils/install_selected_extensions.php /usr/local/bin/install_selected_exten
 ONBUILD ARG PHP_EXTENSIONS
 ONBUILD ENV PHP_EXTENSIONS="$PHP_EXTENSIONS"
 ONBUILD RUN sudo PHP_EXTENSIONS="$PHP_EXTENSIONS" php /usr/local/bin/install_selected_extensions.php
+
+# |--------------------------------------------------------------------------
+# | Supercronic
+# |--------------------------------------------------------------------------
+# |
+# | Supercronic is a drop-in replacement for cron (for containers).
+# |
+
+ONBUILD ARG INSTALL_CRON
+ONBUILD RUN if [ -n "$INSTALL_CRON" ]; then \
+ SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.1.5/supercronic-linux-amd64 \
+ && SUPERCRONIC=supercronic-linux-amd64 \
+ && SUPERCRONIC_SHA1SUM=9aeb41e00cc7b71d30d33c57a2333f2c2581a201 \
+ && curl -fsSLO "$SUPERCRONIC_URL" \
+ && echo "${SUPERCRONIC_SHA1SUM}  ${SUPERCRONIC}" | sha1sum -c - \
+ && chmod +x "$SUPERCRONIC" \
+ && sudo mv "$SUPERCRONIC" "/usr/local/bin/${SUPERCRONIC}" \
+ && sudo ln -s "/usr/local/bin/${SUPERCRONIC}" /usr/local/bin/supercronic; \
+ fi;
+
 
 # |--------------------------------------------------------------------------
 # | NodeJS

--- a/Dockerfile.7.2.slim.cli
+++ b/Dockerfile.7.2.slim.cli
@@ -18,23 +18,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends git nano sudo i
 RUN cd /usr/local/lib/thecodingmachine-php/extensions/current/zip && ./install.sh
 # RUN echo 'extension=zip.so' > /usr/local/etc/php/conf.d/generated_conf.ini
 
-
-# |--------------------------------------------------------------------------
-# | Supercronic
-# |--------------------------------------------------------------------------
-# |
-# | Supercronic is a drop-in replacement for cron (for containers).
-# |
-
-RUN SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.1.5/supercronic-linux-amd64 \
- && SUPERCRONIC=supercronic-linux-amd64 \
- && SUPERCRONIC_SHA1SUM=9aeb41e00cc7b71d30d33c57a2333f2c2581a201 \
- && curl -fsSLO "$SUPERCRONIC_URL" \
- && echo "${SUPERCRONIC_SHA1SUM}  ${SUPERCRONIC}" | sha1sum -c - \
- && chmod +x "$SUPERCRONIC" \
- && mv "$SUPERCRONIC" "/usr/local/bin/${SUPERCRONIC}" \
- && ln -s "/usr/local/bin/${SUPERCRONIC}" /usr/local/bin/supercronic
-
 # |--------------------------------------------------------------------------
 # | User
 # |--------------------------------------------------------------------------
@@ -84,7 +67,10 @@ COPY utils/generate_conf.php /usr/local/bin/generate_conf.php
 # |
 
 USER docker
-RUN composer global require hirak/prestissimo
+RUN composer global require hirak/prestissimo && \
+    composer global require bamarni/symfony-console-autocomplete && \
+    rm -rf $HOME\.composer
+
 USER root
 
 
@@ -122,8 +108,6 @@ RUN mkdir ~/.ssh && touch ~/.ssh/known_hosts && chmod 644 ~/.ssh/known_hosts && 
 # |
 # | Let's update the .bashrc to add nice aliases
 # |
-
-RUN composer global require bamarni/symfony-console-autocomplete
 
 RUN echo 'eval "$(symfony-autocomplete)"' > ~/.bash_profile
 
@@ -181,6 +165,26 @@ COPY utils/install_selected_extensions.php /usr/local/bin/install_selected_exten
 ONBUILD ARG PHP_EXTENSIONS
 ONBUILD ENV PHP_EXTENSIONS="$PHP_EXTENSIONS"
 ONBUILD RUN sudo PHP_EXTENSIONS="$PHP_EXTENSIONS" php /usr/local/bin/install_selected_extensions.php
+
+# |--------------------------------------------------------------------------
+# | Supercronic
+# |--------------------------------------------------------------------------
+# |
+# | Supercronic is a drop-in replacement for cron (for containers).
+# |
+
+ONBUILD ARG INSTALL_CRON
+ONBUILD RUN if [ -n "$INSTALL_CRON" ]; then \
+ SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.1.5/supercronic-linux-amd64 \
+ && SUPERCRONIC=supercronic-linux-amd64 \
+ && SUPERCRONIC_SHA1SUM=9aeb41e00cc7b71d30d33c57a2333f2c2581a201 \
+ && curl -fsSLO "$SUPERCRONIC_URL" \
+ && echo "${SUPERCRONIC_SHA1SUM}  ${SUPERCRONIC}" | sha1sum -c - \
+ && chmod +x "$SUPERCRONIC" \
+ && sudo mv "$SUPERCRONIC" "/usr/local/bin/${SUPERCRONIC}" \
+ && sudo ln -s "/usr/local/bin/${SUPERCRONIC}" /usr/local/bin/supercronic; \
+ fi;
+
 
 # |--------------------------------------------------------------------------
 # | NodeJS

--- a/Dockerfile.7.2.slim.fpm
+++ b/Dockerfile.7.2.slim.fpm
@@ -18,23 +18,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends git nano sudo i
 RUN cd /usr/local/lib/thecodingmachine-php/extensions/current/zip && ./install.sh
 # RUN echo 'extension=zip.so' > /usr/local/etc/php/conf.d/generated_conf.ini
 
-
-# |--------------------------------------------------------------------------
-# | Supercronic
-# |--------------------------------------------------------------------------
-# |
-# | Supercronic is a drop-in replacement for cron (for containers).
-# |
-
-RUN SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.1.5/supercronic-linux-amd64 \
- && SUPERCRONIC=supercronic-linux-amd64 \
- && SUPERCRONIC_SHA1SUM=9aeb41e00cc7b71d30d33c57a2333f2c2581a201 \
- && curl -fsSLO "$SUPERCRONIC_URL" \
- && echo "${SUPERCRONIC_SHA1SUM}  ${SUPERCRONIC}" | sha1sum -c - \
- && chmod +x "$SUPERCRONIC" \
- && mv "$SUPERCRONIC" "/usr/local/bin/${SUPERCRONIC}" \
- && ln -s "/usr/local/bin/${SUPERCRONIC}" /usr/local/bin/supercronic
-
 # |--------------------------------------------------------------------------
 # | User
 # |--------------------------------------------------------------------------
@@ -84,7 +67,10 @@ COPY utils/generate_conf.php /usr/local/bin/generate_conf.php
 # |
 
 USER docker
-RUN composer global require hirak/prestissimo
+RUN composer global require hirak/prestissimo && \
+    composer global require bamarni/symfony-console-autocomplete && \
+    rm -rf $HOME\.composer
+
 USER root
 
 
@@ -121,8 +107,6 @@ RUN mkdir ~/.ssh && touch ~/.ssh/known_hosts && chmod 644 ~/.ssh/known_hosts && 
 # |
 # | Let's update the .bashrc to add nice aliases
 # |
-
-RUN composer global require bamarni/symfony-console-autocomplete
 
 RUN echo 'eval "$(symfony-autocomplete)"' > ~/.bash_profile
 
@@ -180,6 +164,26 @@ COPY utils/install_selected_extensions.php /usr/local/bin/install_selected_exten
 ONBUILD ARG PHP_EXTENSIONS
 ONBUILD ENV PHP_EXTENSIONS="$PHP_EXTENSIONS"
 ONBUILD RUN sudo PHP_EXTENSIONS="$PHP_EXTENSIONS" php /usr/local/bin/install_selected_extensions.php
+
+# |--------------------------------------------------------------------------
+# | Supercronic
+# |--------------------------------------------------------------------------
+# |
+# | Supercronic is a drop-in replacement for cron (for containers).
+# |
+
+ONBUILD ARG INSTALL_CRON
+ONBUILD RUN if [ -n "$INSTALL_CRON" ]; then \
+ SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.1.5/supercronic-linux-amd64 \
+ && SUPERCRONIC=supercronic-linux-amd64 \
+ && SUPERCRONIC_SHA1SUM=9aeb41e00cc7b71d30d33c57a2333f2c2581a201 \
+ && curl -fsSLO "$SUPERCRONIC_URL" \
+ && echo "${SUPERCRONIC_SHA1SUM}  ${SUPERCRONIC}" | sha1sum -c - \
+ && chmod +x "$SUPERCRONIC" \
+ && sudo mv "$SUPERCRONIC" "/usr/local/bin/${SUPERCRONIC}" \
+ && sudo ln -s "/usr/local/bin/${SUPERCRONIC}" /usr/local/bin/supercronic; \
+ fi;
+
 
 # |--------------------------------------------------------------------------
 # | NodeJS

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ This repository contains a set of developer-friendly, general purpose PHP images
  - You can also modify the `php.ini` settings using environment variables.
  - 2 types available: `slim` (no extensions preloaded) or `fat` (most common PHP extensions are built-in)
  - 3 variants available: `CLI`, `apache` and `fpm`
- - Images are bundled with [Supercronic](https://github.com/aptible/supercronic) which is a Cron compatible task runner. Cron jobs can be configured using environment variables
- - Images come with [Composer](https://getcomposer.org/) and [Prestissimo](https://github.com/hirak/prestissimo) installed
+ - Fat images are bundled with [Supercronic](https://github.com/aptible/supercronic) which is a Cron compatible task runner. Cron jobs can be configured using environment variables
+ - Fat images come with [Composer](https://getcomposer.org/) and [Prestissimo](https://github.com/hirak/prestissimo) installed
  - All variants can be installed with or without NodeJS (if you need to build your static assets).
  - Everything is done to limit file permission issues that often arise when using Docker. The image is actively tested on Linux, Windows and MacOS
 
@@ -108,7 +108,7 @@ Below is a list of extensions available in this image:
 
 **Enabled by default:** apcu mysqli opcache pdo pdo_mysql redis zip soap
 
-**Available (can be enabled using environment variables):** amqp ast bcmath blackfire bz2 calendar dba enchant ev event exif gd gettext gmp gnupg igbinary imagick imap intl ldap mcrypt memcached mongodb pcntl pdo_dblib pdo_pgsql pgsql pspell shmop snmp sockets sysvmsg sysvsem sysvshm tidy wddx weakref(-beta) xdebug xmlrpc xsl yaml
+**Available (can be enabled using environment variables):** amqp ast bcmath blackfire bz2 calendar dba ds enchant ev event exif mailparse gd gettext gmp gnupg igbinary imagick imap intl ldap mcrypt memcached mongodb pcntl pdo_dblib pdo_pgsql pgsql pspell shmop snmp sockets swoole sysvmsg sysvsem sysvshm tidy wddx weakref(-beta) xdebug xmlrpc xsl yaml
 
 ### Enabling/disabling extensions in the fat image
 
@@ -353,6 +353,15 @@ CRON_COMMAND_1=vendor/bin/console do:stuff
 CRON_USER_2=www-data
 CRON_SCHEDULE_2=0 3 * * *
 CRON_COMMAND_2=vendor/bin/console other:stuff
+```
+
+Cron is **installed by default in the fat images**. If you are using the "*slim*" images, you need to install it by passing
+a single argument before the "FROM" clause in your Dockerfile:
+
+```Dockerfile
+ARG INSTALL_CRON=1
+FROM thecodingmachine/php:7.2-v2-slim-apache
+# The build triggers automatically the installation of Cron
 ```
 
 **Important**: The cron runner we use is "Supercronic" and not the orginial "cron" that has a number of issues

--- a/utils/Dockerfile.blueprint
+++ b/utils/Dockerfile.blueprint
@@ -2,6 +2,8 @@
 {{- $variant := .Orbit.variant -}}
 {{- $node_version := .Orbit.node_version -}}
 
+ARG INSTALL_CRON=1
+ARG INSTALL_COMPOSER=1
 FROM thecodingmachine/php:{{ $php_version }}-v2-slim-{{ $variant }}{{if .Orbit.node_version }}-node{{ $node_version }}{{end}}
 
 LABEL authors="Julien Neuhart <j.neuhart@thecodingmachine.com>, David Négrier <d.negrier@thecodingmachine.com>"

--- a/utils/Dockerfile.slim.blueprint
+++ b/utils/Dockerfile.slim.blueprint
@@ -21,23 +21,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends git nano sudo i
 RUN cd /usr/local/lib/thecodingmachine-php/extensions/current/zip && ./install.sh
 # RUN echo 'extension=zip.so' > /usr/local/etc/php/conf.d/generated_conf.ini
 
-
-# |--------------------------------------------------------------------------
-# | Supercronic
-# |--------------------------------------------------------------------------
-# |
-# | Supercronic is a drop-in replacement for cron (for containers).
-# |
-
-RUN SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.1.5/supercronic-linux-amd64 \
- && SUPERCRONIC=supercronic-linux-amd64 \
- && SUPERCRONIC_SHA1SUM=9aeb41e00cc7b71d30d33c57a2333f2c2581a201 \
- && curl -fsSLO "$SUPERCRONIC_URL" \
- && echo "${SUPERCRONIC_SHA1SUM}  ${SUPERCRONIC}" | sha1sum -c - \
- && chmod +x "$SUPERCRONIC" \
- && mv "$SUPERCRONIC" "/usr/local/bin/${SUPERCRONIC}" \
- && ln -s "/usr/local/bin/${SUPERCRONIC}" /usr/local/bin/supercronic
-
 # |--------------------------------------------------------------------------
 # | User
 # |--------------------------------------------------------------------------
@@ -87,7 +70,10 @@ COPY utils/generate_conf.php /usr/local/bin/generate_conf.php
 # |
 
 USER docker
-RUN composer global require hirak/prestissimo
+RUN composer global require hirak/prestissimo && \
+    composer global require bamarni/symfony-console-autocomplete && \
+    rm -rf $HOME\.composer
+
 USER root
 
 {{if eq $variant "apache" }}
@@ -141,8 +127,6 @@ RUN mkdir ~/.ssh && touch ~/.ssh/known_hosts && chmod 644 ~/.ssh/known_hosts && 
 # |
 # | Let's update the .bashrc to add nice aliases
 # |
-
-RUN composer global require bamarni/symfony-console-autocomplete
 
 RUN echo 'eval "$(symfony-autocomplete)"' > ~/.bash_profile
 
@@ -223,6 +207,26 @@ COPY utils/install_selected_extensions.php /usr/local/bin/install_selected_exten
 ONBUILD ARG PHP_EXTENSIONS
 ONBUILD ENV PHP_EXTENSIONS="$PHP_EXTENSIONS"
 ONBUILD RUN sudo PHP_EXTENSIONS="$PHP_EXTENSIONS" php /usr/local/bin/install_selected_extensions.php
+
+# |--------------------------------------------------------------------------
+# | Supercronic
+# |--------------------------------------------------------------------------
+# |
+# | Supercronic is a drop-in replacement for cron (for containers).
+# |
+
+ONBUILD ARG INSTALL_CRON
+ONBUILD RUN if [ -n "$INSTALL_CRON" ]; then \
+ SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.1.5/supercronic-linux-amd64 \
+ && SUPERCRONIC=supercronic-linux-amd64 \
+ && SUPERCRONIC_SHA1SUM=9aeb41e00cc7b71d30d33c57a2333f2c2581a201 \
+ && curl -fsSLO "$SUPERCRONIC_URL" \
+ && echo "${SUPERCRONIC_SHA1SUM}  ${SUPERCRONIC}" | sha1sum -c - \
+ && chmod +x "$SUPERCRONIC" \
+ && sudo mv "$SUPERCRONIC" "/usr/local/bin/${SUPERCRONIC}" \
+ && sudo ln -s "/usr/local/bin/${SUPERCRONIC}" /usr/local/bin/supercronic; \
+ fi;
+
 
 # |--------------------------------------------------------------------------
 # | NodeJS

--- a/utils/README.blueprint.md
+++ b/utils/README.blueprint.md
@@ -8,8 +8,8 @@ This repository contains a set of developer-friendly, general purpose PHP images
  - You can also modify the `php.ini` settings using environment variables.
  - 2 types available: `slim` (no extensions preloaded) or `fat` (most common PHP extensions are built-in)
  - 3 variants available: `CLI`, `apache` and `fpm`
- - Images are bundled with [Supercronic](https://github.com/aptible/supercronic) which is a Cron compatible task runner. Cron jobs can be configured using environment variables
- - Images come with [Composer](https://getcomposer.org/) and [Prestissimo](https://github.com/hirak/prestissimo) installed
+ - Fat images are bundled with [Supercronic](https://github.com/aptible/supercronic) which is a Cron compatible task runner. Cron jobs can be configured using environment variables
+ - Fat images come with [Composer](https://getcomposer.org/) and [Prestissimo](https://github.com/hirak/prestissimo) installed
  - All variants can be installed with or without NodeJS (if you need to build your static assets).
  - Everything is done to limit file permission issues that often arise when using Docker. The image is actively tested on Linux, Windows and MacOS
 
@@ -341,6 +341,15 @@ CRON_COMMAND_1=vendor/bin/console do:stuff
 CRON_USER_2=www-data
 CRON_SCHEDULE_2=0 3 * * *
 CRON_COMMAND_2=vendor/bin/console other:stuff
+```
+
+Cron is **installed by default in the fat images**. If you are using the "*slim*" images, you need to install it by passing
+a single argument before the "FROM" clause in your Dockerfile:
+
+```Dockerfile
+ARG INSTALL_CRON=1
+FROM thecodingmachine/php:{{ $image.php_version }}-v2-slim-apache
+# The build triggers automatically the installation of Cron
 ```
 
 **Important**: The cron runner we use is "Supercronic" and not the orginial "cron" that has a number of issues

--- a/utils/generate_cron.php
+++ b/utils/generate_cron.php
@@ -6,8 +6,11 @@
 
 $tiniPid = $argv[1];
 
+$found = false;
+
 foreach ($_SERVER as $key => $command) {
     if (strpos($key, 'CRON_COMMAND') === 0) {
+        $found = true;
         $suffix = substr($key, 12);
 
         $schedule = getenv('CRON_SCHEDULE'.$suffix);
@@ -26,4 +29,10 @@ foreach ($_SERVER as $key => $command) {
 
         echo $schedule.' '.$userCmd.$command."\n";
     }
+}
+
+if (($found === true) && !file_exists('/usr/local/bin/supercronic')) {
+    // Let's check Supercronic is installed (it could be not installed is we are using the slim version...)
+    error_log('Cron is not available in this image. If you are using the thecodingmachine/php "slim" variant, do not forget to add "ARG INSTALL_CRON=1" in your Dockerfile. Check the documentation for more details.');
+    exit(1);
 }


### PR DESCRIPTION
This PR moves Supercronic installation in the fat image, using a ONBUILD script and an additional ARG.