### PR TITLE
Fixing issue with startup.sh

### DIFF
--- a/build-and-test.sh
+++ b/build-and-test.sh
@@ -87,6 +87,8 @@ RESULT=`docker run --rm -e FOO="bar" -e STARTUP_COMMAND_1="env" -e UID=0 thecodi
 RESULT=`docker run --rm -e STARTUP_COMMAND_1="cd / && whoami" -e UID=0 thecodingmachine/php:${PHP_VERSION}-${BRANCH}-slim-${BRANCH_VARIANT} sleep 1`
 [[ "$RESULT" = "root" ]]
 
+# Tests that startup.sh is correctly executed
+docker run --rm -v $PWD/tests/startup.sh:/etc/container/startup.sh thecodingmachine/php:${PHP_VERSION}-${BRANCH}-slim-${BRANCH_VARIANT} php -m | grep "startup.sh executed"
 
 #################################
 # Let's build the "fat" image

--- a/tests/startup.sh
+++ b/tests/startup.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo "startup.sh executed"

--- a/utils/docker-entrypoint-as-root.sh
+++ b/utils/docker-entrypoint-as-root.sh
@@ -116,7 +116,7 @@ if [[ "$IMAGE_VARIANT" == "apache" ]]; then
 fi
 
 if [ -e /etc/container/startup.sh ]; then
-    sudo -E -u "#$DOCKER_USER_ID" source /etc/container/startup.sh
+    sudo -E -u "#$DOCKER_USER_ID" /etc/container/startup.sh
 fi
 sudo -E -u "#$DOCKER_USER_ID" sh -c "php /usr/local/bin/startup_commands.php | bash"
 


### PR DESCRIPTION
`startup.sh` loading is broken.

This PR fixes the issue and adds a unit test.

Closes #94 