### PR TITLE
Enabling memcached and blackfire on PHP 7.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,6 @@ Below is a list of extensions available in this image:
 **Note**: as of 2018-12-13, PHP 7.3 has just been released and some extensions are not yet ready:
 
 - *amqp* extension is not compatible with PHP 7.3 yet
-- *blackfire* is not compatible with PHP 7.3 yet
 - *mcrypt* is not available anymore in PHP 7.3
 - *memcached* is not compatible with PHP 7.3 yet
 - *weakref* is not compatible with PHP 7.3 ([there might not be a version for PHP 7.3](https://wiki.php.net/rfc/weakrefs))

--- a/README.md
+++ b/README.md
@@ -126,7 +126,6 @@ Below is a list of extensions available in this image:
 
 - *amqp* extension is not compatible with PHP 7.3 yet
 - *mcrypt* is not available anymore in PHP 7.3
-- *memcached* is not compatible with PHP 7.3 yet
 - *weakref* is not compatible with PHP 7.3 ([there might not be a version for PHP 7.3](https://wiki.php.net/rfc/weakrefs))
 - *xdebug* is provided in version 2.7.0beta1
 
@@ -591,7 +590,7 @@ This command will generate all the files from the "blueprint" templates.
 You can then test your changes using the `build-and-test.sh` command:
 
 ```bash
-PHP_VERSION=7.2 BRANCH=v2 VARIANT=apache.node10 ./build-and-test.sh
+PHP_VERSION=7.2 BRANCH=v2 VARIANT=apache ./build-and-test.sh
 ```
 
 ## Special thanks

--- a/build-and-test.sh
+++ b/build-and-test.sh
@@ -120,13 +120,11 @@ set -e
 docker run --rm -e PHP_EXTENSION_XDEBUG=1 thecodingmachine/php:${PHP_VERSION}-${BRANCH}-${BRANCH_VARIANT} php -i | grep xdebug.remote_host| grep -v "no value"
 
 # Tests that blackfire + xdebug will output an error
-if [[ "${PHP_VERSION}" != "7.3" ]]; then
-    RESULT=`docker run --rm -e PHP_EXTENSION_XDEBUG=1 -e PHP_EXTENSION_BLACKFIRE=1 thecodingmachine/php:${PHP_VERSION}-${BRANCH}-${BRANCH_VARIANT} php -v 2>&1 | grep 'WARNING: Both Blackfire and Xdebug are enabled. This is not recommended as the PHP engine may not behave as expected. You should strongly consider disabling Xdebug or Blackfire.'`
-    [[ "$RESULT" = "WARNING: Both Blackfire and Xdebug are enabled. This is not recommended as the PHP engine may not behave as expected. You should strongly consider disabling Xdebug or Blackfire." ]]
+RESULT=`docker run --rm -e PHP_EXTENSION_XDEBUG=1 -e PHP_EXTENSION_BLACKFIRE=1 thecodingmachine/php:${PHP_VERSION}-${BRANCH}-${BRANCH_VARIANT} php -v 2>&1 | grep 'WARNING: Both Blackfire and Xdebug are enabled. This is not recommended as the PHP engine may not behave as expected. You should strongly consider disabling Xdebug or Blackfire.'`
+[[ "$RESULT" = "WARNING: Both Blackfire and Xdebug are enabled. This is not recommended as the PHP engine may not behave as expected. You should strongly consider disabling Xdebug or Blackfire." ]]
 
-    # Check that blackfire can be enabled
-    docker run --rm -e PHP_EXTENSION_BLACKFIRE=1 thecodingmachine/php:${PHP_VERSION}-${BRANCH}-${BRANCH_VARIANT} php -m | grep blackfire
-fi
+# Check that blackfire can be enabled
+docker run --rm -e PHP_EXTENSION_BLACKFIRE=1 thecodingmachine/php:${PHP_VERSION}-${BRANCH}-${BRANCH_VARIANT} php -m | grep blackfire
 
 # Let's check that the extensions are enabled when composer is run
 docker build -t test/composer_with_gd --build-arg PHP_VERSION="${PHP_VERSION}" --build-arg BRANCH="$BRANCH" --build-arg BRANCH_VARIANT="$BRANCH_VARIANT" tests/composer

--- a/extensions/7.3/blackfire
+++ b/extensions/7.3/blackfire
@@ -1,0 +1,1 @@
+../core/blackfire

--- a/extensions/7.3/memcached
+++ b/extensions/7.3/memcached
@@ -1,0 +1,1 @@
+../core/memcached

--- a/utils/README.blueprint.md
+++ b/utils/README.blueprint.md
@@ -101,7 +101,6 @@ Below is a list of extensions available in this image:
 **Note**: as of 2018-12-13, PHP 7.3 has just been released and some extensions are not yet ready:
 
 - *amqp* extension is not compatible with PHP 7.3 yet
-- *blackfire* is not compatible with PHP 7.3 yet
 - *mcrypt* is not available anymore in PHP 7.3
 - *memcached* is not compatible with PHP 7.3 yet
 - *weakref* is not compatible with PHP 7.3 ([there might not be a version for PHP 7.3](https://wiki.php.net/rfc/weakrefs))

--- a/utils/README.blueprint.md
+++ b/utils/README.blueprint.md
@@ -102,7 +102,6 @@ Below is a list of extensions available in this image:
 
 - *amqp* extension is not compatible with PHP 7.3 yet
 - *mcrypt* is not available anymore in PHP 7.3
-- *memcached* is not compatible with PHP 7.3 yet
 - *weakref* is not compatible with PHP 7.3 ([there might not be a version for PHP 7.3](https://wiki.php.net/rfc/weakrefs))
 - *xdebug* is provided in version 2.7.0beta1
 
@@ -567,7 +566,7 @@ This command will generate all the files from the "blueprint" templates.
 You can then test your changes using the `build-and-test.sh` command:
 
 ```bash
-PHP_VERSION={{ $image.php_version }} BRANCH=v2 VARIANT=apache.node10 ./build-and-test.sh
+PHP_VERSION={{ $image.php_version }} BRANCH=v2 VARIANT=apache ./build-and-test.sh
 ```
 
 ## Special thanks


### PR DESCRIPTION
Blackfire and Memcached are now compatible with PHP 7.3.
Enabling them back.