### PR TITLE
Switching XDebug back to stable version (2.7.0) 

### DIFF
--- a/extensions/7.3/xdebug
+++ b/extensions/7.3/xdebug
@@ -1,0 +1,1 @@
+../core/xdebug

--- a/extensions/7.3/xdebug/install.sh
+++ b/extensions/7.3/xdebug/install.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-set -e
-
-PECL_EXTENSION=xdebug-2.7.0RC2 PHP_EXT_NAME=xdebug DEPENDENCIES="bind9-host" ../docker-install.sh


### PR DESCRIPTION
Now that it is released for PHP 7.3, we do not need anymore to specify a beta version for xdebug for PHP 7.3.
