### PR TITLE
Fix PHP-FPM fails to open error log: Permission denied

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,9 +638,10 @@ You can then test your changes using the `build-and-test.sh` command:
 PHP_VERSION=7.2 BRANCH=v2 VARIANT=apache ./build-and-test.sh
 ```
 
-### Files to change
+### Adding additional images
 
 To add a new version (php, node, apache, ...), please edit the following files :
+
 - utils/README.blueprint.md 
   - Add your image in this section: Images
 - orbit.yml: Your image in generation task 

--- a/build-and-test.sh
+++ b/build-and-test.sh
@@ -28,6 +28,10 @@ mkdir user1999 && sudo chown 1999:1999 user1999
 ls -al user1999
 RESULT=`docker run --rm -v $(pwd)/user1999:$CONTAINER_CWD thecodingmachine/php:${PHP_VERSION}-${BRANCH}-slim-${BRANCH_VARIANT} id -ur`
 [[ "$RESULT" = "1999" ]]
+
+# Also, the default user can write on stdout and stderr
+docker run --rm -v $(pwd)/user1999:$CONTAINER_CWD thecodingmachine/php:${PHP_VERSION}-${BRANCH}-slim-${BRANCH_VARIANT} bash -c "echo TEST > /proc/self/fd/2"
+
 sudo rm -rf user1999
 
 # and it also works for users with existing IDs in the container

--- a/utils/README.blueprint.md
+++ b/utils/README.blueprint.md
@@ -608,9 +608,10 @@ You can then test your changes using the `build-and-test.sh` command:
 PHP_VERSION={{ $image.php_version }} BRANCH=v2 VARIANT=apache ./build-and-test.sh
 ```
 
-### Files to change
+### Adding additional images
 
 To add a new version (php, node, apache, ...), please edit the following files :
+
 - utils/README.blueprint.md 
   - Add your image in this section: Images
 - orbit.yml: Your image in generation task 

--- a/utils/docker-entrypoint-as-root.sh
+++ b/utils/docker-entrypoint-as-root.sh
@@ -65,6 +65,9 @@ fi
 DOCKER_USER_ID=`id -ur $DOCKER_USER`
 #echo "Docker user id: $DOCKER_USER_ID"
 
+# Fix access rights to stdout and stderr
+chown $DOCKER_USER /proc/self/fd/{1,2}
+
 if [ -z "$XDEBUG_REMOTE_HOST" ]; then
     export XDEBUG_REMOTE_HOST=`/sbin/ip route|awk '/default/ { print $3 }'`
 


### PR DESCRIPTION
This PR is a fix for https://github.com/thecodingmachine/docker-images-php/issues/133
It starts with a failing test
