### PR TITLE
Preventing chown of failing for older Docker versions

### DIFF
--- a/utils/docker-entrypoint-as-root.sh
+++ b/utils/docker-entrypoint-as-root.sh
@@ -66,7 +66,10 @@ DOCKER_USER_ID=`id -ur $DOCKER_USER`
 #echo "Docker user id: $DOCKER_USER_ID"
 
 # Fix access rights to stdout and stderr
+# Note: chown can fail on older versions of Docker (seen failing on Docker 17.06 on CentOS)
+set +e
 chown $DOCKER_USER /proc/self/fd/{1,2}
+set -e
 
 if [ -z "$XDEBUG_REMOTE_HOST" ]; then
     export XDEBUG_REMOTE_HOST=`/sbin/ip route|awk '/default/ { print $3 }'`


### PR DESCRIPTION
The `chown docker` command added in #139 can fail with Docker 17.06 on CentOS (maybe more versions are affected?)
This PR makes sure the error does not prevent the system to start.