### PR TITLE
Fix a small readme copy-paste error.

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ services:
 As an alternative, you can use the `APACHE_EXTENSIONS` global variable:
 
 ```
-PHP_EXTENSIONS="dav ssl"
+APACHE_EXTENSIONS="dav ssl"
 ```
 
 **Apache modules enabled by default:** access_compat, alias, auth_basic, authn_core, authn_file, authz_core, authz_host, authz_user, autoindex, deflate, dir, env, expires, filter, mime, mpm_prefork, negotiation, php7, reqtimeout, rewrite, setenvif, status


### PR DESCRIPTION
**Summary**

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

* [x] `PHP_EXTENSIONS` used in the docs instead of `APACHE_EXTENSIONS`