### PR TITLE
Fixing missing AllowOverride in Apache v3 images

### DIFF
--- a/utils/Dockerfile.slim.blueprint
+++ b/utils/Dockerfile.slim.blueprint
@@ -153,6 +153,9 @@ RUN apt-get update \
 RUN sed -ri -e 's!/var/www/html!${ABSOLUTE_APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf
 RUN sed -ri -e 's!/var/www/!${ABSOLUTE_APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
 
+COPY utils/apache-docker-php.conf /etc/apache2/conf-available/docker-php.conf
+RUN a2enconf docker-php
+
 # |--------------------------------------------------------------------------
 # | Apache mod_rewrite
 # |--------------------------------------------------------------------------

--- a/utils/apache-docker-php.conf
+++ b/utils/apache-docker-php.conf
@@ -1,0 +1,11 @@
+<FilesMatch \.php$>
+        SetHandler application/x-httpd-php
+</FilesMatch>
+
+DirectoryIndex disabled
+DirectoryIndex index.php index.html
+
+<Directory /var/www/html/${APACHE_DOCUMENT_ROOT}>
+        Options -Indexes
+        AllowOverride All
+</Directory>


### PR DESCRIPTION
This PR fixes a regression in v3 images: AllowOverride was disabled by default.