### PR TITLE
Fixing wrong php.ini file for Apache and FPM variants

### DIFF
--- a/Dockerfile.slim.apache
+++ b/Dockerfile.slim.apache
@@ -69,8 +69,9 @@ RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 ENV TEMPLATE_PHP_INI=development
 
-# Let's remove the default php.ini file (it will be copied from TEMPLATE_PHP_INI)
-RUN rm /etc/php/${PHP_VERSION}/cli/php.ini
+# Let's remove the default php.ini files (they will be copied from TEMPLATE_PHP_INI)
+RUN rm /etc/php/${PHP_VERSION}/cli/php.ini &&\
+    rm /etc/php/${PHP_VERSION}/apache2/php.ini
 
 
 # |--------------------------------------------------------------------------
@@ -311,7 +312,7 @@ CMD ["apache2-foreground"]
 # | Entrypoint
 # |--------------------------------------------------------------------------
 # |
-# | Defines Apache user. Bu default, we switch this to "docker" user.
+# | Defines Apache user. By default, we switch this to "docker" user.
 # | This way, no problem to write from Apache in the current working directory.
 # | Important! This should be changed back to www-data in production.
 # |

--- a/Dockerfile.slim.apache
+++ b/Dockerfile.slim.apache
@@ -69,9 +69,15 @@ RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 ENV TEMPLATE_PHP_INI=development
 
-# Let's remove the default php.ini files (they will be copied from TEMPLATE_PHP_INI)
-RUN rm /etc/php/${PHP_VERSION}/cli/php.ini &&\
-    rm /etc/php/${PHP_VERSION}/apache2/php.ini
+# Let's remove the default CLI php.ini file (it will be copied from TEMPLATE_PHP_INI)
+RUN rm /etc/php/${PHP_VERSION}/cli/php.ini
+
+
+# Let's remove the default Apache php.ini file (it will be copied from TEMPLATE_PHP_INI)
+RUN rm /etc/php/${PHP_VERSION}/apache2/php.ini
+
+
+
 
 
 # |--------------------------------------------------------------------------

--- a/Dockerfile.slim.apache
+++ b/Dockerfile.slim.apache
@@ -72,14 +72,6 @@ ENV TEMPLATE_PHP_INI=development
 # Let's remove the default CLI php.ini file (it will be copied from TEMPLATE_PHP_INI)
 RUN rm /etc/php/${PHP_VERSION}/cli/php.ini
 
-
-# Let's remove the default Apache php.ini file (it will be copied from TEMPLATE_PHP_INI)
-RUN rm /etc/php/${PHP_VERSION}/apache2/php.ini
-
-
-
-
-
 # |--------------------------------------------------------------------------
 # | Composer
 # |--------------------------------------------------------------------------
@@ -209,6 +201,8 @@ ENV APACHE_DOCUMENT_ROOT=
 RUN sed -ri -e 's!/var/www/html!${ABSOLUTE_APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf
 RUN sed -ri -e 's!/var/www/!${ABSOLUTE_APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
 
+# Let's remove the default Apache php.ini file (it will be copied from TEMPLATE_PHP_INI)
+RUN rm /etc/php/${PHP_VERSION}/apache2/php.ini
 
 # |--------------------------------------------------------------------------
 # | Apache mod_rewrite

--- a/Dockerfile.slim.cli
+++ b/Dockerfile.slim.cli
@@ -69,9 +69,12 @@ RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 ENV TEMPLATE_PHP_INI=development
 
-# Let's remove the default php.ini files (they will be copied from TEMPLATE_PHP_INI)
-RUN rm /etc/php/${PHP_VERSION}/cli/php.ini &&\
-    rm /etc/php/${PHP_VERSION}/apache2/php.ini
+# Let's remove the default CLI php.ini file (it will be copied from TEMPLATE_PHP_INI)
+RUN rm /etc/php/${PHP_VERSION}/cli/php.ini
+
+
+
+
 
 
 # |--------------------------------------------------------------------------

--- a/Dockerfile.slim.cli
+++ b/Dockerfile.slim.cli
@@ -69,8 +69,9 @@ RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 ENV TEMPLATE_PHP_INI=development
 
-# Let's remove the default php.ini file (it will be copied from TEMPLATE_PHP_INI)
-RUN rm /etc/php/${PHP_VERSION}/cli/php.ini
+# Let's remove the default php.ini files (they will be copied from TEMPLATE_PHP_INI)
+RUN rm /etc/php/${PHP_VERSION}/cli/php.ini &&\
+    rm /etc/php/${PHP_VERSION}/apache2/php.ini
 
 
 # |--------------------------------------------------------------------------

--- a/Dockerfile.slim.cli
+++ b/Dockerfile.slim.cli
@@ -72,11 +72,6 @@ ENV TEMPLATE_PHP_INI=development
 # Let's remove the default CLI php.ini file (it will be copied from TEMPLATE_PHP_INI)
 RUN rm /etc/php/${PHP_VERSION}/cli/php.ini
 
-
-
-
-
-
 # |--------------------------------------------------------------------------
 # | Composer
 # |--------------------------------------------------------------------------

--- a/Dockerfile.slim.fpm
+++ b/Dockerfile.slim.fpm
@@ -69,9 +69,15 @@ RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 ENV TEMPLATE_PHP_INI=development
 
-# Let's remove the default php.ini files (they will be copied from TEMPLATE_PHP_INI)
-RUN rm /etc/php/${PHP_VERSION}/cli/php.ini &&\
-    rm /etc/php/${PHP_VERSION}/apache2/php.ini
+# Let's remove the default CLI php.ini file (it will be copied from TEMPLATE_PHP_INI)
+RUN rm /etc/php/${PHP_VERSION}/cli/php.ini
+
+
+
+
+# Let's remove the default PHP-FPM php.ini file (it will be copied from TEMPLATE_PHP_INI)
+RUN rm /etc/php/${PHP_VERSION}/fpm/php.ini
+
 
 
 # |--------------------------------------------------------------------------

--- a/Dockerfile.slim.fpm
+++ b/Dockerfile.slim.fpm
@@ -72,14 +72,6 @@ ENV TEMPLATE_PHP_INI=development
 # Let's remove the default CLI php.ini file (it will be copied from TEMPLATE_PHP_INI)
 RUN rm /etc/php/${PHP_VERSION}/cli/php.ini
 
-
-
-
-# Let's remove the default PHP-FPM php.ini file (it will be copied from TEMPLATE_PHP_INI)
-RUN rm /etc/php/${PHP_VERSION}/fpm/php.ini
-
-
-
 # |--------------------------------------------------------------------------
 # | Composer
 # |--------------------------------------------------------------------------
@@ -153,6 +145,9 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends php${PHP_VERSION}-fpm \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
+
+# Let's remove the default PHP-FPM php.ini file (it will be copied from TEMPLATE_PHP_INI)
+RUN rm /etc/php/${PHP_VERSION}/fpm/php.ini
 
 
 

--- a/Dockerfile.slim.fpm
+++ b/Dockerfile.slim.fpm
@@ -69,8 +69,9 @@ RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 ENV TEMPLATE_PHP_INI=development
 
-# Let's remove the default php.ini file (it will be copied from TEMPLATE_PHP_INI)
-RUN rm /etc/php/${PHP_VERSION}/cli/php.ini
+# Let's remove the default php.ini files (they will be copied from TEMPLATE_PHP_INI)
+RUN rm /etc/php/${PHP_VERSION}/cli/php.ini &&\
+    rm /etc/php/${PHP_VERSION}/apache2/php.ini
 
 
 # |--------------------------------------------------------------------------

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 TheCodingMachine
+Copyright (c) 2020 TheCodingMachine
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/orbit.yml
+++ b/orbit.yml
@@ -34,5 +34,4 @@ tasks:
       - orbit generate -f utils/Dockerfile.node.blueprint -o Dockerfile.fpm.node8 -p "variant,fpm;node_version,8"
       - orbit generate -f utils/Dockerfile.node.blueprint -o Dockerfile.fpm.node10 -p "variant,fpm;node_version,10"
       - orbit generate -f utils/Dockerfile.node.blueprint -o Dockerfile.fpm.node12 -p "variant,fpm;node_version,12"
-
       - orbit generate -f utils/README.blueprint.md -o README.md

--- a/utils/Dockerfile.slim.blueprint
+++ b/utils/Dockerfile.slim.blueprint
@@ -71,8 +71,9 @@ RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 ENV TEMPLATE_PHP_INI=development
 
-# Let's remove the default php.ini file (it will be copied from TEMPLATE_PHP_INI)
-RUN rm /etc/php/${PHP_VERSION}/cli/php.ini
+# Let's remove the default php.ini files (they will be copied from TEMPLATE_PHP_INI)
+RUN rm /etc/php/${PHP_VERSION}/cli/php.ini &&\
+    rm /etc/php/${PHP_VERSION}/apache2/php.ini
 
 
 # |--------------------------------------------------------------------------
@@ -323,7 +324,7 @@ CMD ["apache2-foreground"]
 # | Entrypoint
 # |--------------------------------------------------------------------------
 # |
-# | Defines Apache user. Bu default, we switch this to "docker" user.
+# | Defines Apache user. By default, we switch this to "docker" user.
 # | This way, no problem to write from Apache in the current working directory.
 # | Important! This should be changed back to www-data in production.
 # |

--- a/utils/Dockerfile.slim.blueprint
+++ b/utils/Dockerfile.slim.blueprint
@@ -74,17 +74,6 @@ ENV TEMPLATE_PHP_INI=development
 # Let's remove the default CLI php.ini file (it will be copied from TEMPLATE_PHP_INI)
 RUN rm /etc/php/${PHP_VERSION}/cli/php.ini
 
-{{if eq $variant "apache" }}
-# Let's remove the default Apache php.ini file (it will be copied from TEMPLATE_PHP_INI)
-RUN rm /etc/php/${PHP_VERSION}/apache2/php.ini
-{{end}}
-
-{{if eq $variant "fpm" }}
-# Let's remove the default PHP-FPM php.ini file (it will be copied from TEMPLATE_PHP_INI)
-RUN rm /etc/php/${PHP_VERSION}/fpm/php.ini
-{{end}}
-
-
 # |--------------------------------------------------------------------------
 # | Composer
 # |--------------------------------------------------------------------------
@@ -214,6 +203,8 @@ ENV APACHE_DOCUMENT_ROOT=
 RUN sed -ri -e 's!/var/www/html!${ABSOLUTE_APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf
 RUN sed -ri -e 's!/var/www/!${ABSOLUTE_APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
 
+# Let's remove the default Apache php.ini file (it will be copied from TEMPLATE_PHP_INI)
+RUN rm /etc/php/${PHP_VERSION}/apache2/php.ini
 
 # |--------------------------------------------------------------------------
 # | Apache mod_rewrite
@@ -230,6 +221,9 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends php${PHP_VERSION}-fpm \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
+
+# Let's remove the default PHP-FPM php.ini file (it will be copied from TEMPLATE_PHP_INI)
+RUN rm /etc/php/${PHP_VERSION}/fpm/php.ini
 {{end}}
 
 

--- a/utils/Dockerfile.slim.blueprint
+++ b/utils/Dockerfile.slim.blueprint
@@ -71,9 +71,18 @@ RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 ENV TEMPLATE_PHP_INI=development
 
-# Let's remove the default php.ini files (they will be copied from TEMPLATE_PHP_INI)
-RUN rm /etc/php/${PHP_VERSION}/cli/php.ini &&\
-    rm /etc/php/${PHP_VERSION}/apache2/php.ini
+# Let's remove the default CLI php.ini file (it will be copied from TEMPLATE_PHP_INI)
+RUN rm /etc/php/${PHP_VERSION}/cli/php.ini
+
+{{if eq $variant "apache" }}
+# Let's remove the default Apache php.ini file (it will be copied from TEMPLATE_PHP_INI)
+RUN rm /etc/php/${PHP_VERSION}/apache2/php.ini
+{{end}}
+
+{{if eq $variant "fpm" }}
+# Let's remove the default PHP-FPM php.ini file (it will be copied from TEMPLATE_PHP_INI)
+RUN rm /etc/php/${PHP_VERSION}/fpm/php.ini
+{{end}}
 
 
 # |--------------------------------------------------------------------------

--- a/utils/docker-entrypoint-as-root.sh
+++ b/utils/docker-entrypoint-as-root.sh
@@ -7,9 +7,16 @@ touch /opt/container_started
 
 # Let's apply the requested php.ini file
 
-# TODO: APACHE AND PHP-FPM
 if [ ! -f /etc/php/${PHP_VERSION}/cli/php.ini ] || [ -L /etc/php/${PHP_VERSION}/cli/php.ini ]; then
     ln -sf /usr/lib/php/${PHP_VERSION}/php.ini-${TEMPLATE_PHP_INI} /etc/php/${PHP_VERSION}/cli/php.ini
+fi
+
+if [[ "$IMAGE_VARIANT" == "apache" ]]; then
+    ln -sf /usr/lib/php/${PHP_VERSION}/php.ini-${TEMPLATE_PHP_INI} /etc/php/${PHP_VERSION}/apache2/php.ini
+fi
+
+if [[ "$IMAGE_VARIANT" == "fpm" ]]; then
+    ln -sf /usr/lib/php/${PHP_VERSION}/php.ini-${TEMPLATE_PHP_INI} /etc/php/${PHP_VERSION}/fpm/php.ini
 fi
 
 # Let's find the user to use for commands.


### PR DESCRIPTION
The default Ubuntu `php.ini` file is currently used in the Apache and FPM variants.

Instead, we want to use the generated `php.ini` already used by PHP CLI.