### PR TITLE
Adding back SQLite3 (as an available extension)

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Below is a list of extensions available in this image:
 
 **Enabled by default (in addition to extensions enabled in Slim image):** apcu mysqli pdo_mysql igbinary redis soap
 
-**Available (can be enabled using environment variables):** amqp ast bcmath blackfire bz2 calendar dba ds enchant ev event exif mailparse msgpack gd gettext gmp gnupg igbinary imagick imap intl ldap mcrypt memcached mongodb pcntl pcov pdo_dblib pdo_pgsql pgsql pspell shmop snmp sockets swoole tidy weakref(-beta) xdebug xmlrpc xsl yaml
+**Available (can be enabled using environment variables):** amqp ast bcmath blackfire bz2 calendar dba ds enchant ev event exif mailparse msgpack gd gettext gmp gnupg igbinary imagick imap intl ldap mcrypt memcached mongodb pcntl pcov pdo_dblib pdo_pgsql pgsql pspell shmop snmp sockets sqlite3 swoole tidy weakref(-beta) xdebug xmlrpc xsl yaml
 
 **Note**: as of 2019-11-28, PHP 7.4 has just been released and some extensions are not yet ready:
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Below is a list of extensions available in this image:
 
 **Enabled by default (in addition to extensions enabled in Slim image):** apcu mysqli pdo_mysql igbinary redis soap
 
-**Available (can be enabled using environment variables):** amqp ast bcmath blackfire bz2 calendar dba ds enchant ev event exif mailparse msgpack gd gettext gmp gnupg igbinary imagick imap intl ldap mcrypt memcached mongodb pcntl pcov pdo_dblib pdo_pgsql pgsql pspell shmop snmp sockets sqlite3 swoole tidy weakref(-beta) xdebug xmlrpc xsl yaml
+**Available (can be enabled using environment variables):** amqp ast bcmath blackfire bz2 calendar dba ds enchant ev event exif mailparse msgpack gd gettext gmp gnupg igbinary imagick imap intl ldap mcrypt memcached mongodb pcntl pcov pdo_dblib pdo_pgsql pdo_sqlite pgsql pspell shmop snmp sockets sqlite3 swoole tidy weakref(-beta) xdebug xmlrpc xsl yaml
 
 **Note**: as of 2019-11-28, PHP 7.4 has just been released and some extensions are not yet ready:
 

--- a/extensions/7.1/sqlite3
+++ b/extensions/7.1/sqlite3
@@ -1,0 +1,1 @@
+../core/sqlite3/

--- a/extensions/7.2/sqlite3
+++ b/extensions/7.2/sqlite3
@@ -1,0 +1,1 @@
+../core/sqlite3/

--- a/extensions/7.3/sqlite3
+++ b/extensions/7.3/sqlite3
@@ -1,0 +1,1 @@
+../core/sqlite3/

--- a/extensions/7.4/sqlite3
+++ b/extensions/7.4/sqlite3
@@ -1,0 +1,1 @@
+../core/sqlite3/

--- a/extensions/core/sqlite3/install.sh
+++ b/extensions/core/sqlite3/install.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -e
+export EXTENSION=sqlite3
+
+../docker-install.sh

--- a/utils/README.blueprint.md
+++ b/utils/README.blueprint.md
@@ -101,7 +101,7 @@ Below is a list of extensions available in this image:
 
 **Enabled by default (in addition to extensions enabled in Slim image):** apcu mysqli pdo_mysql igbinary redis soap
 
-**Available (can be enabled using environment variables):** amqp ast bcmath blackfire bz2 calendar dba ds enchant ev event exif mailparse msgpack gd gettext gmp gnupg igbinary imagick imap intl ldap mcrypt memcached mongodb pcntl pcov pdo_dblib pdo_pgsql pgsql pspell shmop snmp sockets sqlite3 swoole tidy weakref(-beta) xdebug xmlrpc xsl yaml
+**Available (can be enabled using environment variables):** amqp ast bcmath blackfire bz2 calendar dba ds enchant ev event exif mailparse msgpack gd gettext gmp gnupg igbinary imagick imap intl ldap mcrypt memcached mongodb pcntl pcov pdo_dblib pdo_pgsql pdo_sqlite pgsql pspell shmop snmp sockets sqlite3 swoole tidy weakref(-beta) xdebug xmlrpc xsl yaml
 
 **Note**: as of 2019-11-28, PHP 7.4 has just been released and some extensions are not yet ready:
 

--- a/utils/README.blueprint.md
+++ b/utils/README.blueprint.md
@@ -101,7 +101,7 @@ Below is a list of extensions available in this image:
 
 **Enabled by default (in addition to extensions enabled in Slim image):** apcu mysqli pdo_mysql igbinary redis soap
 
-**Available (can be enabled using environment variables):** amqp ast bcmath blackfire bz2 calendar dba ds enchant ev event exif mailparse msgpack gd gettext gmp gnupg igbinary imagick imap intl ldap mcrypt memcached mongodb pcntl pcov pdo_dblib pdo_pgsql pgsql pspell shmop snmp sockets swoole tidy weakref(-beta) xdebug xmlrpc xsl yaml
+**Available (can be enabled using environment variables):** amqp ast bcmath blackfire bz2 calendar dba ds enchant ev event exif mailparse msgpack gd gettext gmp gnupg igbinary imagick imap intl ldap mcrypt memcached mongodb pcntl pcov pdo_dblib pdo_pgsql pgsql pspell shmop snmp sockets sqlite3 swoole tidy weakref(-beta) xdebug xmlrpc xsl yaml
 
 **Note**: as of 2019-11-28, PHP 7.4 has just been released and some extensions are not yet ready:
 


### PR DESCRIPTION
This PR adds the SQLite 3 extension.
Unlike in v2 images, the extension is not enabled by default and must be enabled using

`PHP_EXTENSION_SQLITE3: 1`

Closes #163 