### PR TITLE
Adding a php.ini CLI file for development

### DIFF
--- a/Dockerfile.slim.apache
+++ b/Dockerfile.slim.apache
@@ -60,8 +60,13 @@ RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 # | Default php.ini file
 # |--------------------------------------------------------------------------
 # |
-# | Let's download php.ini for prod and development
+# | For some reasons, the official image has a php.ini-production.cli file
+# | but no php.ini-development.cli file. Let's create this one.
 # |
+
+RUN cp /usr/lib/php/${PHP_VERSION}/php.ini-development /usr/lib/php/${PHP_VERSION}/php.ini-development.cli && \
+    sed -i 's/^disable_functions/;disable_functions/g' /usr/lib/php/${PHP_VERSION}/php.ini-development.cli && \
+    sed -i 's/^memory_limit = .*/memory_limit = -1/g' /usr/lib/php/${PHP_VERSION}/php.ini-development.cli
 
 #ADD https://raw.githubusercontent.com/php/php-src/PHP-${PHP_VERSION}/php.ini-production /usr/local/etc/php/php.ini-production
 #ADD https://raw.githubusercontent.com/php/php-src/PHP-${PHP_VERSION}/php.ini-development /usr/local/etc/php/php.ini-development

--- a/Dockerfile.slim.cli
+++ b/Dockerfile.slim.cli
@@ -60,8 +60,13 @@ RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 # | Default php.ini file
 # |--------------------------------------------------------------------------
 # |
-# | Let's download php.ini for prod and development
+# | For some reasons, the official image has a php.ini-production.cli file
+# | but no php.ini-development.cli file. Let's create this one.
 # |
+
+RUN cp /usr/lib/php/${PHP_VERSION}/php.ini-development /usr/lib/php/${PHP_VERSION}/php.ini-development.cli && \
+    sed -i 's/^disable_functions/;disable_functions/g' /usr/lib/php/${PHP_VERSION}/php.ini-development.cli && \
+    sed -i 's/^memory_limit = .*/memory_limit = -1/g' /usr/lib/php/${PHP_VERSION}/php.ini-development.cli
 
 #ADD https://raw.githubusercontent.com/php/php-src/PHP-${PHP_VERSION}/php.ini-production /usr/local/etc/php/php.ini-production
 #ADD https://raw.githubusercontent.com/php/php-src/PHP-${PHP_VERSION}/php.ini-development /usr/local/etc/php/php.ini-development

--- a/Dockerfile.slim.fpm
+++ b/Dockerfile.slim.fpm
@@ -60,8 +60,13 @@ RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 # | Default php.ini file
 # |--------------------------------------------------------------------------
 # |
-# | Let's download php.ini for prod and development
+# | For some reasons, the official image has a php.ini-production.cli file
+# | but no php.ini-development.cli file. Let's create this one.
 # |
+
+RUN cp /usr/lib/php/${PHP_VERSION}/php.ini-development /usr/lib/php/${PHP_VERSION}/php.ini-development.cli && \
+    sed -i 's/^disable_functions/;disable_functions/g' /usr/lib/php/${PHP_VERSION}/php.ini-development.cli && \
+    sed -i 's/^memory_limit = .*/memory_limit = -1/g' /usr/lib/php/${PHP_VERSION}/php.ini-development.cli
 
 #ADD https://raw.githubusercontent.com/php/php-src/PHP-${PHP_VERSION}/php.ini-production /usr/local/etc/php/php.ini-production
 #ADD https://raw.githubusercontent.com/php/php-src/PHP-${PHP_VERSION}/php.ini-development /usr/local/etc/php/php.ini-development

--- a/build-and-test.sh
+++ b/build-and-test.sh
@@ -141,6 +141,10 @@ RESULT=`docker run --rm -e STARTUP_COMMAND_1="cd / && whoami" -e UID=0 thecoding
 # Tests that startup.sh is correctly executed
 docker run --rm -v $PWD/tests/startup.sh:/etc/container/startup.sh thecodingmachine/php:${PHP_VERSION}-${BRANCH}-slim-${BRANCH_VARIANT} php -m | grep "startup.sh executed"
 
+# Tests that disable_functions is commented in php.ini cli
+RESULT=`docker run --rm thecodingmachine/php:${PHP_VERSION}-${BRANCH}-slim-${BRANCH_VARIANT} php -i | grep "disable_functions"`
+[[ "$RESULT" = "disable_functions => no value => no value" ]]
+
 #################################
 # Let's build the "fat" image
 #################################

--- a/utils/Dockerfile.slim.blueprint
+++ b/utils/Dockerfile.slim.blueprint
@@ -62,8 +62,13 @@ RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 # | Default php.ini file
 # |--------------------------------------------------------------------------
 # |
-# | Let's download php.ini for prod and development
+# | For some reasons, the official image has a php.ini-production.cli file
+# | but no php.ini-development.cli file. Let's create this one.
 # |
+
+RUN cp /usr/lib/php/${PHP_VERSION}/php.ini-development /usr/lib/php/${PHP_VERSION}/php.ini-development.cli && \
+    sed -i 's/^disable_functions/;disable_functions/g' /usr/lib/php/${PHP_VERSION}/php.ini-development.cli && \
+    sed -i 's/^memory_limit = .*/memory_limit = -1/g' /usr/lib/php/${PHP_VERSION}/php.ini-development.cli
 
 #ADD https://raw.githubusercontent.com/php/php-src/PHP-${PHP_VERSION}/php.ini-production /usr/local/etc/php/php.ini-production
 #ADD https://raw.githubusercontent.com/php/php-src/PHP-${PHP_VERSION}/php.ini-development /usr/local/etc/php/php.ini-development

--- a/utils/docker-entrypoint-as-root.sh
+++ b/utils/docker-entrypoint-as-root.sh
@@ -8,7 +8,7 @@ touch /opt/container_started
 # Let's apply the requested php.ini file
 
 if [ ! -f /etc/php/${PHP_VERSION}/cli/php.ini ] || [ -L /etc/php/${PHP_VERSION}/cli/php.ini ]; then
-    ln -sf /usr/lib/php/${PHP_VERSION}/php.ini-${TEMPLATE_PHP_INI} /etc/php/${PHP_VERSION}/cli/php.ini
+    ln -sf /usr/lib/php/${PHP_VERSION}/php.ini-${TEMPLATE_PHP_INI}.cli /etc/php/${PHP_VERSION}/cli/php.ini
 fi
 
 if [[ "$IMAGE_VARIANT" == "apache" ]]; then


### PR DESCRIPTION
This file is missing in standard Ubuntu PPA and is needed if we want to have no "disable_functions" in dev CLI.
Closes #168 