### PR TITLE
Fix `watchtower` project url

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ When 7.1.13 is out, you certainly want to upgrade automatically to this patch re
 
 Images are automatically updated when a new patch version of PHP is released, so the PHP 7.1 image will always contain 
 the most up-to-date version of the PHP 7.1.x branch. If you want to automatically update your images on your production
-environment, you can use tools like [watchtower](https://github.com/v3tec/watchtower) that will monitor new versions of
+environment, you can use tools like [watchtower](https://github.com/containrrr/watchtower) that will monitor new versions of
 the images and update your environment on the fly.
 
 ## Usage


### PR DESCRIPTION
**Summary**

<!-- Summary of the PR -->

This updates the `watchtower` project url to <https://github.com/containrrr/watchtower>. I am unfamiliar with both this project (`thecodingmachine/docker-images-php`) and `watchtower` and found the broken link while RTM, so I made the best guess possible via Google & GitHub. Feel free to correct, close, etc!

This PR fixes/implements the following **bugs**

* [x] https://github.com/v3tec/watchtower 404s

---

- [x] Have you followed the guidelines in our [CONTRIBUTING](CONTRIBUTING.md) guide?
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code