### PR TITLE
Enabling blackfire for PHP 7.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,9 +148,8 @@ Below is a list of extensions available in this image:
 
 **Available (can be enabled using environment variables):** amqp ast bcmath blackfire bz2 calendar dba ds enchant ev event exif mailparse msgpack gd gettext gmp gnupg igbinary imagick imap intl ldap mcrypt memcached mongodb pcntl pcov pdo_dblib pdo_pgsql pdo_sqlite pgsql pspell shmop snmp sockets sqlite3 swoole tidy weakref(-beta) xdebug xmlrpc xsl yaml
 
-**Note**: as of 2019-11-28, PHP 7.4 has just been released and some extensions are not yet ready:
+**Note**:
 
-- *blackfire* extension is not compatible with PHP 7.4 yet
 - *mcrypt* is not available anymore in PHP 7.3+
 - *weakref* is not compatible with PHP 7.3+ (but weak references were added to the PHP core in PHP 7.4)
 

--- a/extensions/7.4/blackfire
+++ b/extensions/7.4/blackfire
@@ -1,0 +1,1 @@
+../core/blackfire/

--- a/utils/README.blueprint.md
+++ b/utils/README.blueprint.md
@@ -103,9 +103,8 @@ Below is a list of extensions available in this image:
 
 **Available (can be enabled using environment variables):** amqp ast bcmath blackfire bz2 calendar dba ds enchant ev event exif mailparse msgpack gd gettext gmp gnupg igbinary imagick imap intl ldap mcrypt memcached mongodb pcntl pcov pdo_dblib pdo_pgsql pdo_sqlite pgsql pspell shmop snmp sockets sqlite3 swoole tidy weakref(-beta) xdebug xmlrpc xsl yaml
 
-**Note**: as of 2019-11-28, PHP 7.4 has just been released and some extensions are not yet ready:
+**Note**:
 
-- *blackfire* extension is not compatible with PHP 7.4 yet
 - *mcrypt* is not available anymore in PHP 7.3+
 - *weakref* is not compatible with PHP 7.3+ (but weak references were added to the PHP core in PHP 7.4)
 


### PR DESCRIPTION
Support for PHP 7.4 was added in Blackfire
Thir PR enables the blackfire extension for PHP 7.4

Thanks @bastnic !
Closes #177 