### PR TITLE
Putting absolute path for utils.php inclusion

### DIFF
--- a/utils/generate_conf.php
+++ b/utils/generate_conf.php
@@ -4,7 +4,7 @@
  * The script is run on each start of the container.
  */
 
-require 'utils.php';
+require __DIR__.'/utils.php';
 
 // Reading environment variables from $_SERVER (because $_ENV is not necessarily populated, depending on variables_order directive):
 

--- a/utils/install_selected_extensions.php
+++ b/utils/install_selected_extensions.php
@@ -4,7 +4,7 @@
  * The script is run "ONBUILD".
  */
 
-require 'utils.php';
+require __DIR__.'/utils.php';
 
 echo "*** Installing extensions ***\n";
 

--- a/utils/setup_extensions.php
+++ b/utils/setup_extensions.php
@@ -5,7 +5,7 @@
  * The script is run on each start of the container.
  */
 
-require 'utils.php';
+require __DIR__.'/utils.php';
 
 $compiledExtensions = [
     /*'ftp', 'mysqlnd', 'mbstring'*/


### PR DESCRIPTION
If we don't do this, if a file is named "utils.php" at the root of a project, it will be used instead of our own utils.php file.
Closes #173
