### PR TITLE
Adding ext-uploadprogress to FAT image

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Below is a list of extensions available in this image:
 
 **Enabled by default (in addition to extensions enabled in Slim image):** apcu mysqli pdo_mysql igbinary redis soap
 
-**Available (can be enabled using environment variables):** amqp ast bcmath blackfire bz2 calendar dba ds enchant ev event exif mailparse msgpack gd gettext gmp gnupg igbinary imagick imap intl ldap mcrypt memcached mongodb pcntl pcov pdo_dblib pdo_pgsql pdo_sqlite pgsql pspell shmop snmp sockets sqlite3 swoole tidy weakref(-beta) xdebug xmlrpc xsl yaml
+**Available (can be enabled using environment variables):** amqp ast bcmath blackfire bz2 calendar dba ds enchant ev event exif mailparse msgpack gd gettext gmp gnupg igbinary imagick imap intl ldap mcrypt memcached mongodb pcntl pcov pdo_dblib pdo_pgsql pdo_sqlite pgsql pspell shmop snmp sockets sqlite3 swoole tidy uploadprogress weakref(-beta) xdebug xmlrpc xsl yaml
 
 **Note**:
 

--- a/extensions/7.1/uploadprogress
+++ b/extensions/7.1/uploadprogress
@@ -1,0 +1,1 @@
+../core/uploadprogress/

--- a/extensions/7.2/uploadprogress
+++ b/extensions/7.2/uploadprogress
@@ -1,0 +1,1 @@
+../core/uploadprogress/

--- a/extensions/7.3/uploadprogress
+++ b/extensions/7.3/uploadprogress
@@ -1,0 +1,1 @@
+../core/uploadprogress/

--- a/extensions/7.4/uploadprogress
+++ b/extensions/7.4/uploadprogress
@@ -1,0 +1,1 @@
+../core/uploadprogress/

--- a/extensions/core/uploadprogress/install.sh
+++ b/extensions/core/uploadprogress/install.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -e
+export PECL_EXTENSION=uploadprogress
+
+../docker-install.sh


### PR DESCRIPTION
Following the recent update of the extension, we can now consider including it in the FAT image.
Closes #112
