### PR TITLE
Upgrade Supercronic and add SUPERCRONIC_OPTIONS variable

### DIFF
--- a/Dockerfile.slim.apache
+++ b/Dockerfile.slim.apache
@@ -351,12 +351,13 @@ ONBUILD RUN sudo -E PHP_EXTENSIONS="$PHP_EXTENSIONS" /usr/local/bin/install_sele
 # |
 # | Supercronic is a drop-in replacement for cron (for containers).
 # |
+ENV SUPERCRONIC_OPTIONS=
 
 ONBUILD ARG INSTALL_CRON
 ONBUILD RUN if [ -n "$INSTALL_CRON" ]; then \
- SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.1.5/supercronic-linux-amd64 \
+ SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.1.9/supercronic-linux-amd64 \
  && SUPERCRONIC=supercronic-linux-amd64 \
- && SUPERCRONIC_SHA1SUM=9aeb41e00cc7b71d30d33c57a2333f2c2581a201 \
+ && SUPERCRONIC_SHA1SUM=5ddf8ea26b56d4a7ff6faecdd8966610d5cb9d85 \
  && curl -fsSLO "$SUPERCRONIC_URL" \
  && echo "${SUPERCRONIC_SHA1SUM}  ${SUPERCRONIC}" | sha1sum -c - \
  && chmod +x "$SUPERCRONIC" \

--- a/Dockerfile.slim.cli
+++ b/Dockerfile.slim.cli
@@ -256,12 +256,13 @@ ONBUILD RUN sudo -E PHP_EXTENSIONS="$PHP_EXTENSIONS" /usr/local/bin/install_sele
 # |
 # | Supercronic is a drop-in replacement for cron (for containers).
 # |
+ENV SUPERCRONIC_OPTIONS=
 
 ONBUILD ARG INSTALL_CRON
 ONBUILD RUN if [ -n "$INSTALL_CRON" ]; then \
- SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.1.5/supercronic-linux-amd64 \
+ SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.1.9/supercronic-linux-amd64 \
  && SUPERCRONIC=supercronic-linux-amd64 \
- && SUPERCRONIC_SHA1SUM=9aeb41e00cc7b71d30d33c57a2333f2c2581a201 \
+ && SUPERCRONIC_SHA1SUM=5ddf8ea26b56d4a7ff6faecdd8966610d5cb9d85 \
  && curl -fsSLO "$SUPERCRONIC_URL" \
  && echo "${SUPERCRONIC_SHA1SUM}  ${SUPERCRONIC}" | sha1sum -c - \
  && chmod +x "$SUPERCRONIC" \

--- a/Dockerfile.slim.fpm
+++ b/Dockerfile.slim.fpm
@@ -279,12 +279,13 @@ ONBUILD RUN sudo -E PHP_EXTENSIONS="$PHP_EXTENSIONS" /usr/local/bin/install_sele
 # |
 # | Supercronic is a drop-in replacement for cron (for containers).
 # |
+ENV SUPERCRONIC_OPTIONS=
 
 ONBUILD ARG INSTALL_CRON
 ONBUILD RUN if [ -n "$INSTALL_CRON" ]; then \
- SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.1.5/supercronic-linux-amd64 \
+ SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.1.9/supercronic-linux-amd64 \
  && SUPERCRONIC=supercronic-linux-amd64 \
- && SUPERCRONIC_SHA1SUM=9aeb41e00cc7b71d30d33c57a2333f2c2581a201 \
+ && SUPERCRONIC_SHA1SUM=5ddf8ea26b56d4a7ff6faecdd8966610d5cb9d85 \
  && curl -fsSLO "$SUPERCRONIC_URL" \
  && echo "${SUPERCRONIC_SHA1SUM}  ${SUPERCRONIC}" | sha1sum -c - \
  && chmod +x "$SUPERCRONIC" \

--- a/README.md
+++ b/README.md
@@ -460,6 +460,21 @@ CRON_SCHEDULE_1=0 1 * * *
 CRON_COMMAND_1=vendor/bin/console do:stuff
 ```
 
+### Supercronic options
+To specify Supercronic options you can set the `SUPERCRONIC_OPTIONS` environment variable.
+
+This can be used to enable duplicate jobs. Per default, Supercronic will wait for a given job to finish before that job is scheduled again.\
+With the option `-overlapping` Supercronic will run duplicate instances of the jobs instead of waiting for them.
+
+```bash
+SUPERCRONIC_OPTIONS=-overlapping
+
+# Or multiple options
+SUPERCRONIC_OPTIONS=-overlapping -debug
+```
+
+For more options see see the [Supercronic Documentation](https://github.com/aptible/supercronic/blob/master/README.md).
+
 ## Launching commands on container startup
 
 You can launch commands on container startup using the `STARTUP_COMMAND_XXX` environment variables.

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Below is a list of extensions available in this image:
 
 **Enabled by default (in addition to extensions enabled in Slim image):** apcu mysqli pdo_mysql igbinary redis soap
 
-**Available (can be enabled using environment variables):** amqp ast bcmath blackfire bz2 calendar dba ds enchant ev event exif mailparse msgpack gd gettext gmp gnupg igbinary imagick imap intl ldap mcrypt memcached mongodb pcntl pcov pdo_dblib pdo_pgsql pdo_sqlite pgsql pspell shmop snmp sockets sqlite3 swoole tidy uploadprogress weakref(-beta) xdebug xmlrpc xsl yaml
+**Available (can be enabled using environment variables):** amqp ast bcmath blackfire bz2 calendar dba ds enchant ev event exif mailparse msgpack gd gettext gmp gnupg igbinary imagick imap intl ldap mcrypt memcached mongodb pcntl pcov pdo_dblib pdo_pgsql pdo_sqlite pgsql pspell shmop snmp sockets sqlite3 swoole tidy weakref(-beta) xdebug xmlrpc xsl yaml
 
 **Note**:
 

--- a/utils/Dockerfile.slim.blueprint
+++ b/utils/Dockerfile.slim.blueprint
@@ -383,12 +383,13 @@ ONBUILD RUN sudo -E PHP_EXTENSIONS="$PHP_EXTENSIONS" /usr/local/bin/install_sele
 # |
 # | Supercronic is a drop-in replacement for cron (for containers).
 # |
+ENV SUPERCRONIC_OPTIONS=
 
 ONBUILD ARG INSTALL_CRON
 ONBUILD RUN if [ -n "$INSTALL_CRON" ]; then \
- SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.1.5/supercronic-linux-amd64 \
+ SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.1.9/supercronic-linux-amd64 \
  && SUPERCRONIC=supercronic-linux-amd64 \
- && SUPERCRONIC_SHA1SUM=9aeb41e00cc7b71d30d33c57a2333f2c2581a201 \
+ && SUPERCRONIC_SHA1SUM=5ddf8ea26b56d4a7ff6faecdd8966610d5cb9d85 \
  && curl -fsSLO "$SUPERCRONIC_URL" \
  && echo "${SUPERCRONIC_SHA1SUM}  ${SUPERCRONIC}" | sha1sum -c - \
  && chmod +x "$SUPERCRONIC" \

--- a/utils/README.blueprint.md
+++ b/utils/README.blueprint.md
@@ -415,6 +415,21 @@ CRON_SCHEDULE_1=0 1 * * *
 CRON_COMMAND_1=vendor/bin/console do:stuff
 ```
 
+### Supercronic options
+To specify Supercronic options you can set the `SUPERCRONIC_OPTIONS` environment variable.
+
+This can be used to enable duplicate jobs. Per default, Supercronic will wait for a given job to finish before that job is scheduled again.\
+With the option `-overlapping` Supercronic will run duplicate instances of the jobs instead of waiting for them.
+
+```bash
+SUPERCRONIC_OPTIONS=-overlapping
+
+# Or multiple options
+SUPERCRONIC_OPTIONS=-overlapping -debug
+```
+
+For more options see see the [Supercronic Documentation](https://github.com/aptible/supercronic/blob/master/README.md).
+
 ## Launching commands on container startup
 
 You can launch commands on container startup using the `STARTUP_COMMAND_XXX` environment variables.

--- a/utils/docker-entrypoint-as-root.sh
+++ b/utils/docker-entrypoint-as-root.sh
@@ -126,7 +126,7 @@ chmod 0644 /tmp/generated_crontab
 
 # If generated_crontab is not empty, start supercronic
 if [[ -s /tmp/generated_crontab ]]; then
-    supercronic /tmp/generated_crontab &
+    supercronic ${SUPERCRONIC_OPTIONS} /tmp/generated_crontab &
 fi
 
 if [[ "$IMAGE_VARIANT" == "apache" ]]; then


### PR DESCRIPTION
**Summary**

Upgrades Supercronic from v0.1.5 to v0.1.9. Adds a SUPERCRONIC_OPTIONS ENV-variable so you can set options like "-overlapping".  The older version of Supercronic did not have the overlapping feature. With the overlapping feature you long running cronjobs will not block other cronjobs.


**Closing issues**

closes #184