### PR TITLE
Fix: Composer proxy is swallowing exit code of real composer

### DIFF
--- a/utils/composer_proxy.php
+++ b/utils/composer_proxy.php
@@ -12,4 +12,5 @@ array_shift($argv);
 $args = array_map(function(string $item) { return escapeshellarg($item); }, $argv);
 
 // Let's pass the command down to the real composer
-passthru('real_composer '.implode(' ', $args));
+passthru('real_composer '.implode(' ', $args), $exitCode);
+exit($exitCode);


### PR DESCRIPTION
**Summary**
The composer proxy script swallows the exit code of the `real_composer` command. Therefore every composer command executed returns the exit code 0 even though they failed.

**Test plan (required)**
Without the fix:
```
$ composer run test:unit
...
ERRORS!
Tests: 19, Assertions: 17, Errors: 3.
Script ./vendor/bin/phpunit --config phpunit.unit.xml --testdox handling the test:unit event returned with error code 2
$ echo $?
0
```

With fix:
```
$ composer run test:unit
...
ERRORS!
Tests: 19, Assertions: 17, Errors: 3.
Script ./vendor/bin/phpunit --config phpunit.unit.xml --testdox handling the test:unit event returned with error code 2
$ echo $?
2
```

**Checklist**

- [x] Have you followed the guidelines in our [CONTRIBUTING](CONTRIBUTING.md) guide?
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code