### PR TITLE
Fixing broken SMTP option

### DIFF
--- a/build-and-test.sh
+++ b/build-and-test.sh
@@ -131,7 +131,7 @@ RESULT=`docker run --rm -e PHP_INI_SESSION__SAVE_PATH="tcp://localhost?auth=your
 [[ "$RESULT" = "session.save_path => tcp://localhost?auth=yourverycomplex\"passwordhere => tcp://localhost?auth=yourverycomplex\"passwordhere" ]]
 
 # Tests that the SMTP parameter is set in uppercase
-RESULT=`docker run --rm -e PHP_INI_SMTP="192.168.0.1" thecodingmachine/php:${PHP_VERSION}-${BRANCH}-slim-${BRANCH_VARIANT} php -i | grep "SMTP"`
+RESULT=`docker run --rm -e PHP_INI_SMTP="192.168.0.1" thecodingmachine/php:${PHP_VERSION}-${BRANCH}-slim-${BRANCH_VARIANT} php -i | grep "^SMTP"`
 [[ "$RESULT" = "SMTP => 192.168.0.1 => 192.168.0.1" ]]
 
 # Tests that environment variables are passed to startup scripts when UID is set

--- a/build-and-test.sh
+++ b/build-and-test.sh
@@ -130,6 +130,10 @@ RESULT=`docker run --rm -e PHP_INI_ERROR_REPORTING="E_ERROR | E_WARNING" thecodi
 RESULT=`docker run --rm -e PHP_INI_SESSION__SAVE_PATH="tcp://localhost?auth=yourverycomplex\"passwordhere" thecodingmachine/php:${PHP_VERSION}-${BRANCH}-slim-${BRANCH_VARIANT} php -i | grep "session.save_path"`
 [[ "$RESULT" = "session.save_path => tcp://localhost?auth=yourverycomplex\"passwordhere => tcp://localhost?auth=yourverycomplex\"passwordhere" ]]
 
+# Tests that the SMTP parameter is set in uppercase
+RESULT=`docker run --rm -e PHP_INI_SMTP="192.168.0.1" thecodingmachine/php:${PHP_VERSION}-${BRANCH}-slim-${BRANCH_VARIANT} php -i | grep "SMTP"`
+[[ "$RESULT" = "SMTP => 192.168.0.1 => 192.168.0.1" ]]
+
 # Tests that environment variables are passed to startup scripts when UID is set
 RESULT=`docker run --rm -e FOO="bar" -e STARTUP_COMMAND_1="env" -e UID=0 thecodingmachine/php:${PHP_VERSION}-${BRANCH}-slim-${BRANCH_VARIANT} sleep 1 | grep "FOO"`
 [[ "$RESULT" = "FOO=bar" ]]

--- a/utils/generate_conf.php
+++ b/utils/generate_conf.php
@@ -10,7 +10,11 @@ require __DIR__.'/utils.php';
 
 foreach ($_SERVER as $key => $value) {
     if (strpos($key, 'PHP_INI_') === 0) {
-        $iniParam = strtolower(substr($key, 8));
+        $iniParam = substr($key, 8);
+        if ($iniParam !== 'SMTP') {
+            // SMTP is the only php.ini parameter that contains uppercase letters (!)
+            $iniParam = strtolower($iniParam);
+        }
         $iniParam = str_replace('__', '.', $iniParam);
         // Let's protect the value if this is a string.
         if (!is_numeric($value) && $iniParam !== 'error_reporting') {


### PR DESCRIPTION
The SMTP option is the only option in php.ini that is uppercase (!)
We need a special case for it.

This PR starts with a failing test.

Closes #191 