### PR TITLE
Enforce Composer 1.x for now

### DIFF
--- a/Dockerfile.slim.apache
+++ b/Dockerfile.slim.apache
@@ -86,7 +86,7 @@ RUN rm /etc/php/${PHP_VERSION}/cli/php.ini
 
 #ENV COMPOSER_ALLOW_SUPERUSER 1
 
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=real_composer &&\
+RUN curl -sS https://getcomposer.org/installer | php -- --1 --install-dir=/usr/local/bin --filename=real_composer &&\
     chmod +x /usr/local/bin/real_composer
 
 # TODO: utils.php in /usr/local/bin... bof!

--- a/Dockerfile.slim.cli
+++ b/Dockerfile.slim.cli
@@ -86,7 +86,7 @@ RUN rm /etc/php/${PHP_VERSION}/cli/php.ini
 
 #ENV COMPOSER_ALLOW_SUPERUSER 1
 
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=real_composer &&\
+RUN curl -sS https://getcomposer.org/installer | php -- --1 --install-dir=/usr/local/bin --filename=real_composer &&\
     chmod +x /usr/local/bin/real_composer
 
 # TODO: utils.php in /usr/local/bin... bof!

--- a/Dockerfile.slim.fpm
+++ b/Dockerfile.slim.fpm
@@ -86,7 +86,7 @@ RUN rm /etc/php/${PHP_VERSION}/cli/php.ini
 
 #ENV COMPOSER_ALLOW_SUPERUSER 1
 
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=real_composer &&\
+RUN curl -sS https://getcomposer.org/installer | php -- --1 --install-dir=/usr/local/bin --filename=real_composer &&\
     chmod +x /usr/local/bin/real_composer
 
 # TODO: utils.php in /usr/local/bin... bof!

--- a/utils/Dockerfile.slim.blueprint
+++ b/utils/Dockerfile.slim.blueprint
@@ -88,7 +88,7 @@ RUN rm /etc/php/${PHP_VERSION}/cli/php.ini
 
 #ENV COMPOSER_ALLOW_SUPERUSER 1
 
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=real_composer &&\
+RUN curl -sS https://getcomposer.org/installer | php -- --1 --install-dir=/usr/local/bin --filename=real_composer &&\
     chmod +x /usr/local/bin/real_composer
 
 # TODO: utils.php in /usr/local/bin... bof!


### PR DESCRIPTION
**Summary**

Enforce Composer 1.x for now, this keeps the current setup running before it is explicitly adjusted
for Composer 2.x.

This PR fixes/implements the following **bugs/features**

* [x] Build failures due to automatic upgrade to Composer 2.x

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Explain the **motivation** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Test plan (required)**

Demonstrate the code is solid. Example: The exact commands you ran and their output.

**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #

**Checklist**

- [ ] Have you followed the guidelines in our [CONTRIBUTING](CONTRIBUTING.md) guide?
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code