### PR TITLE
Feature: dynamic xdebug.mode instead of hardcoded to debug

### DIFF
--- a/utils/generate_conf.php
+++ b/utils/generate_conf.php
@@ -27,7 +27,7 @@ foreach ($_SERVER as $key => $value) {
 if (enableExtension('xdebug')) {
     //echo "zend_extension=xdebug.so\n";
     echo "xdebug.client_host=".getenv('XDEBUG_CLIENT_HOST')."\n";
-    echo "xdebug.mode=debug\n";
+    echo "xdebug.mode=".getenv('PHP_INI_XDEBUG__MODE')."\n";
     //echo "xdebug.remote_autostart=off\n";
     //echo "xdebug.remote_port=9000\n";
     //echo "xdebug.remote_connect_back=0\n";


### PR DESCRIPTION
Sometimes it's critical for debugging to have xdebug.mode config flexible, so it'd be good if we could set it via PHP_INI_XDEBUG__MODE
