### PR TITLE
Hot fix - install 'event' extension using PECL

### DIFF
--- a/extensions/core/event/install.sh
+++ b/extensions/core/event/install.sh
@@ -3,6 +3,7 @@
 set -e
 # Sockets is required for event extension to work.
 #export EXTENSION="sockets"
+export USE_PECL=1
 export PECL_EXTENSION="event"
 export DEV_DEPENDENCIES="libevent-dev libssl-dev"
 export DEPENDENCIES="libevent-2.1-7 libevent-core-2.1-7 libevent-extra-2.1-7 libevent-openssl-2.1-7 libevent-pthreads-2.1-7 libssl1.1"


### PR DESCRIPTION
Using `pickle` to install extension `event` leads to following error:
```console
> PHP_VERSION=7.4 BRANCH=v4 VARIANT=apache ./build-and-test.sh
...
+ pickle install event
  - Installing event (latest-stable): Downloading (100%)         

In VersionParser.php line 185:
                                    
  Invalid version string "3.0.2r1"
```
This is due to the fact that [latest version of `event`](https://pecl.php.net/package/event/3.0.2r1), released about a month ago, is formatted in a way unrecognized by [composer/semver](https://github.com/composer/semver/blob/main/src/VersionParser.php#L185).

It seems, however, that `pecl` is perfectly capable of installing this version.

Maybe another approach would be to systematically use `pecl` as fallback in case `pickle` failed an installation?

Anyhoot, this will probably be reverted as soon as a new version of `event` is released.