### PR TITLE
Support rdkafka extension for PHP 8.0

### DIFF
--- a/extensions/8.0/rdfafka
+++ b/extensions/8.0/rdfafka
@@ -1,0 +1,1 @@
+../core/rdkafka


### PR DESCRIPTION
**Summary**

Rdkafka extension was not available at the time of PHP 8.0 release. It is now [with 5.0 release](https://github.com/arnaud-lb/php-rdkafka/releases/tag/5.0.0).

This PR fixes/implements the following **features**

* [x] #247

