### PR TITLE
Document the XDEBUG_CLIENT_HOST env variable

### DIFF
--- a/utils/README.blueprint.md
+++ b/utils/README.blueprint.md
@@ -285,6 +285,14 @@ Behind the scenes, the image will:
 - if you are using a Linux machine, the `xdebug.client_host` IP will point to your Docker gateway
 - if you are using a Windows or MaxOS machine, the `xdebug.client_host` IP will point to [`host.docker.internal`](https://docs.docker.com/docker-for-mac/networking/#use-cases-and-workarounds) or [`docker.for.mac.localhost`](https://docs.docker.com/docker-for-mac/networking/#use-cases-and-workarounds)
 
+If you want to debug directly inside your container (for example if you're using [VSCode devcontainers](https://code.visualstudio.com/docs/remote/containers)) you can overwrite the [`xdebug.client_host`](https://xdebug.org/docs/all_settings#client_host) value by setting the following environment variable:
+
+```bash
+XDEBUG_CLIENT_HOST=127.0.0.1
+```
+
+In that case the manually set value takes precedence over the mentioned ones above.
+
 ## NodeJS
 
 The *fat* images come with a Node variant. You can use Node 10, 12, 14 or 16. If you need a Node 8 variant, [use thecodingmachine/php v3 images](https://github.com/thecodingmachine/docker-images-php/tree/v3). If you need a Node 6 variant, [use thecodingmachine/php v1 images](https://github.com/thecodingmachine/docker-images-php/tree/7.2-v1).


### PR DESCRIPTION
**Summary**

This PR documents the behaviour of the `XDEBUG_CLIENT_HOST` variable which is set in https://github.com/thecodingmachine/docker-images-php/blob/d655294dc86efac13982bdfd64b3a8e1770f99e1/utils/docker-entrypoint-as-root.sh#L84 only if it's not set already. Settings this variable to localhost comes in handy when using VSCode devcontainers.

This PR fixes/implements :

* [ ] Bug
* [x] Feature 
* [ ] Breaking changes

Explain the **motivation** for making this change. What existing problem does the pull request solve?

With the mentioned environment variable `XDEBUG_CLIENT_HOST` set to `127.0.0.1` it's possible to attach VSCode to a running php container and then debug locally directly inside that container instead of bridging the xdebug request to the host system.

**Test plan (required)**

Not required since only updated docs. But i testet setting the variable via docker environment variables and it works like expected.

**Checklist**

- [x] I followed the guidelines in [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code