### PR TITLE
Gracefully stop php process

### DIFF
--- a/utils/php_proxy.sh
+++ b/utils/php_proxy.sh
@@ -15,4 +15,4 @@ if [[ "$REGENERATE" == "1" ]]; then
   /usr/bin/real_php /usr/local/bin/setup_extensions.php | sudo bash
 fi
 
-/usr/bin/real_php "$@"
+exec /usr/bin/real_php "$@"


### PR DESCRIPTION
**Summary**

This PR fixes/implements :

* [x] Gracefully stop php process

When we run php process in docker container, it actually uses `utils/php_proxy.sh` shell script to run php process. But that would cause the php process to be ran in a sub shell, then when we stop docker container, the stop signal forwarded from PID 1 process would not continue forwarding to the php process by the sub shell. So we need to use `exec` command to run php process to replace the sub shell, and then the php process can properly receive stop signal to stop gracefully. 

**Checklist**

- [x] I followed the guidelines in [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code