### PR TITLE
Fix/explicit php versioning

### DIFF
--- a/extensions/core/disable_all.sh
+++ b/extensions/core/disable_all.sh
@@ -8,6 +8,6 @@ for ext in */; do \
     if compgen -G "/etc/php/${PHP_VERSION}/cli/conf.d/*-$ext_no_slash.ini" > /dev/null; then
         echo "***************** Disabling $ext_no_slash ******************"
         #rm -f /etc/php/${PHP_VERSION}/cli/conf.d/*-$ext_no_slash.ini
-        phpdismod $ext_no_slash
+        phpdismod -v $PHP_VERSION $ext_no_slash
     fi
 done

--- a/extensions/core/docker-install.sh
+++ b/extensions/core/docker-install.sh
@@ -54,24 +54,24 @@ fi
 
 if [ -n "$EXTENSION" ]; then
     # Let's perform a test
-    phpenmod $EXTENSION
+    phpenmod -v $PHP_VERSION $EXTENSION
     /usr/bin/real_php -m | grep "${PHP_EXT_PHP_NAME:-${PHP_EXT_NAME:-$EXTENSION}}"
     # Check that there is no output on STDERR when starting php:
     OUTPUT=`/usr/bin/real_php -r "echo '';" 2>&1`
     [[ "$OUTPUT" == "" ]]
     # And now, let's disable it!
-    phpdismod $EXTENSION
+    phpdismod -v $PHP_VERSION $EXTENSION
 fi
 
 if [ -n "$PECL_EXTENSION" ]; then
     # Let's perform a test
-    PHP_EXTENSIONS="${PHP_EXT_NAME:-$PECL_EXTENSION}" /usr/bin/real_php /usr/local/bin/setup_extensions.php | bash
+    PHP_EXTENSIONS="${PHP_EXT_NAME:-$PECL_EXTENSION}" PHP_VERSION="${PHP_VERSION}" /usr/bin/real_php /usr/local/bin/setup_extensions.php | bash
     PHP_EXTENSIONS="${PHP_EXT_NAME:-$PECL_EXTENSION}" /usr/bin/real_php /usr/local/bin/generate_conf.php > /etc/php/${PHP_VERSION}/cli/conf.d/testextension.ini
 
     /usr/bin/real_php -m | grep "${PHP_EXT_PHP_NAME:-${PHP_EXT_NAME:-$PECL_EXTENSION}}"
     # Check that there is no output on STDERR when starting php:
     OUTPUT=`/usr/bin/real_php -r "echo '';" 2>&1`
     [[ "$OUTPUT" == "" ]]
-    PHP_EXTENSIONS="" /usr/bin/real_php /usr/local/bin/setup_extensions.php | bash
+    PHP_EXTENSIONS="" PHP_VERSION="${PHP_VERSION}" /usr/bin/real_php /usr/local/bin/setup_extensions.php | bash
     rm /etc/php/${PHP_VERSION}/cli/conf.d/testextension.ini
 fi

--- a/extensions/core/memcached/install.sh
+++ b/extensions/core/memcached/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
-export DEPENDENCIES="php-igbinary php-msgpack"
+export DEPENDENCIES="php${PHP_VERSION}-igbinary php${PHP_VERSION}-msgpack"
 export EXTENSION=memcached
 
 # we need to do some weird stuff to get memcached working

--- a/extensions/core/memcached/install.sh
+++ b/extensions/core/memcached/install.sh
@@ -5,9 +5,9 @@ export DEPENDENCIES="php-igbinary php-msgpack"
 export EXTENSION=memcached
 
 # we need to do some weird stuff to get memcached working
-phpdismod igbinary
-phpenmod igbinary
+phpdismod -v $PHP_VERSION igbinary
+phpenmod -v $PHP_VERSION igbinary
 
 ../docker-install.sh
 
-phpdismod igbinary
+phpdismod -v $PHP_VERSION igbinary

--- a/extensions/core/mysqli/install.sh
+++ b/extensions/core/mysqli/install.sh
@@ -7,5 +7,5 @@ export PACKAGE_NAME=mysql
 ../docker-install.sh
 
 # Exception for this package that enables both mysqlnd and mysqli and pdo_mysql
-phpdismod mysqli
-phpdismod pdo_mysql
+phpdismod -v $PHP_VERSION mysqli
+phpdismod -v $PHP_VERSION pdo_mysql

--- a/extensions/core/redis/install.sh
+++ b/extensions/core/redis/install.sh
@@ -4,9 +4,9 @@ set -e
 export EXTENSION=redis
 
 # we need to do some weird stuff to get memcached working
-phpdismod igbinary
-phpenmod igbinary
+phpdismod -v $PHP_VERSION igbinary
+phpenmod -v $PHP_VERSION igbinary
 
 ../docker-install.sh
 
-phpdismod igbinary
+phpdismod -v $PHP_VERSION igbinary

--- a/utils/docker-entrypoint-as-root.sh
+++ b/utils/docker-entrypoint-as-root.sh
@@ -120,7 +120,7 @@ sudo chown docker:docker /opt/php_env_var_cache.php
 /usr/bin/real_php /usr/local/bin/check_php_env_var_changes.php &> /dev/null
 
 /usr/bin/real_php /usr/local/bin/generate_conf.php > /etc/php/${PHP_VERSION}/mods-available/generated_conf.ini
-/usr/bin/real_php /usr/local/bin/setup_extensions.php | sudo bash
+PHP_VERSION="${PHP_VERSION}" /usr/bin/real_php /usr/local/bin/setup_extensions.php | sudo bash
 
 # output on the logs can be done by writing on the "tini" PID. Useful for CRONTAB
 TINI_PID=`ps -e | grep tini | awk '{print $1;}'`

--- a/utils/php_proxy.sh
+++ b/utils/php_proxy.sh
@@ -12,7 +12,7 @@ fi
 
 if [[ "$REGENERATE" == "1" ]]; then
   /usr/bin/real_php /usr/local/bin/generate_conf.php | sudo tee "/etc/php/${PHP_VERSION}/mods-available/generated_conf.ini" > /dev/null
-  /usr/bin/real_php /usr/local/bin/setup_extensions.php | sudo bash
+  PHP_VERSION="${PHP_VERSION}" /usr/bin/real_php /usr/local/bin/setup_extensions.php | sudo bash
 fi
 
 exec /usr/bin/real_php "$@"

--- a/utils/setup_extensions.php
+++ b/utils/setup_extensions.php
@@ -15,6 +15,8 @@ $availableExtensions = getAvailableExtensions();
 
 $phpExtensions = getPhpExtensionsEnvVar();
 
+$phpVersion = getPhpVersionEnvVar();
+
 //foreach ($compiledExtensions as $phpExtension) {
 //    $envName = 'PHP_EXTENSION_'.strtoupper($phpExtension);
 //
@@ -66,8 +68,8 @@ if (enableExtension('mysqli') || enableExtension('pdo_mysql')) {
 }*/
 
 if ($toDisable) {
-    echo 'phpdismod '.implode(' ', $toDisable)."\n";
+    echo 'phpdismod -v ' . $phpVersion . ' ' . implode(' ', $toDisable)."\n";
 }
 if ($toEnable) {
-    echo 'phpenmod '.implode(' ', $toEnable)."\n";
+    echo 'phpenmod -v ' . $phpVersion . ' ' . implode(' ', $toEnable)."\n";
 }

--- a/utils/utils.php
+++ b/utils/utils.php
@@ -73,6 +73,19 @@ function getPhpExtensionsEnvVar(): array
     return $phpExtensions;
 }
 
+function getPhpVersionEnvVar()
+{
+    static $phpVersion = null;
+    if ($phpVersion !== null) {
+        return $phpVersion;
+    }
+
+    $phpVersion = getenv('PHP_VERSION');
+
+    return $phpVersion;
+}
+
+
 function enableExtension(string $extensionName): bool {
     $phpExtensions = getPhpExtensionsEnvVar();
 


### PR DESCRIPTION
This PR fixes/implements :

[x] Bug: Can't enable memcached extension (closes #286)
[x] Bug: Build errors (closes #290)
[x] Feature: Ensures PHP version is always explicitly set when using `phpenmod` and `phpdismod`

Installing `igbinary` either directly, or as a dependency of `memcached` triggers PHP 8.1 to be installed alongside whatever verion you 'should be using' This then means that `phpenmod` by default points to 8.1, and as we have not installed `memcached` for 8.1 the command fails.

I believe the upstream cause of this is that apt package `php-igbinary` points to `php8.1-igbinary`, regardless of your currently installed PHP version

This pull request:

- Ensures that the `-v` flag is passed to `phpenmod` / `phpdismod` with the correct `$PHP_VERSION`, so if for some reason there are multiple versions installed the correct version will have the module enabled / disabled
- In the install script for `memcached` (at `extensions/core/memcached/install.sh`), explicitly sets the versions of `php-igbinary` and `php-msgpack` to `php${PHP_VERSION}-igbinary` and `php${PHP_VERSION}-msgpack`
    - It would be better to perform a similar check, via `apt-search`, to see if there is a version-specific package available for php-* items in the `DEPENDENCIES` variable.  Currently the dependencies are installed in quite a 'blunt-force' manner: `apt-get install -y --no-install-recommends $DEV_DEPENDENCIES $DEPENDENCIES`.
    - This is out-of-scope for this PR, but I have opened an issue #292

**Testing**
I tested across 7.4 / 8.0 / 8.1 - FPM / Apache / CLI, but only once for each variation: 
- FPM / 7.4
- Apache / 8.0
- CLI / 8.1

Given the changes I made are all in the base image I think these test are sufficient.

Full testing output:

```
# PHP_VERSION=8.0 BRANCH=v4 VARIANT=apache ./build-and-test.sh
[+] Building 3.6s (53/53) FINISHED                                                                      
 => [internal] load build definition from Dockerfile.slim.apache                                   0.1s
 => => transferring dockerfile: 14.42kB                                                            0.0s
 => [internal] load .dockerignore                                                                  0.1s
 => => transferring context: 2B                                                                    0.0s
 => [internal] load metadata for docker.io/library/ubuntu:20.04                                    0.0s
 => [internal] load build context                                                                  0.0s
 => => transferring context: 22.09kB                                                               0.0s
 => https://github.com/krallin/tini/releases/download/v0.16.1/tini                                 0.5s
 => [ 1/47] FROM docker.io/library/ubuntu:20.04                                                    0.0s
 => CACHED [ 2/47] RUN apt-get update     && apt-get install -y --no-install-recommends gnupg      0.0s
 => CACHED [ 3/47] RUN useradd -ms /bin/bash docker && adduser docker sudo                         0.0s
 => CACHED [ 4/47] RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers                         0.0s
 => CACHED [ 5/47] RUN cp /usr/lib/php/8.0/php.ini-development /usr/lib/php/8.0/php.ini-developme  0.0s
 => CACHED [ 6/47] RUN rm /etc/php/8.0/cli/php.ini                                                 0.0s
 => CACHED [ 7/47] RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/loc  0.0s
 => CACHED [ 8/47] COPY utils/utils.php /usr/local/bin/utils.php                                   0.0s
 => CACHED [ 9/47] RUN mv /usr/bin/php /usr/bin/real_php                                           0.0s
 => CACHED [10/47] COPY utils/php_proxy.sh /usr/bin/php                                            0.0s
 => CACHED [11/47] COPY utils/check_php_env_var_changes.php /usr/local/bin/check_php_env_var_chan  0.0s
 => CACHED [12/47] COPY utils/php_env_var_cache.php /opt/php_env_var_cache.php                     0.0s
 => CACHED [13/47] COPY utils/generate_conf.php /usr/local/bin/generate_conf.php                   0.0s
 => CACHED [14/47] COPY utils/setup_extensions.php /usr/local/bin/setup_extensions.php             0.0s
 => CACHED [15/47] RUN composer global require bamarni/symfony-console-autocomplete &&     rm -rf  0.0s
 => CACHED [16/47] RUN set -eux;  apt-get update;  apt-get install -y --no-install-recommends apa  0.0s
 => CACHED [17/47] RUN a2dismod mpm_event && a2enmod mpm_prefork                                   0.0s
 => CACHED [18/47] COPY utils/apache-docker-php.conf /etc/apache2/conf-available/docker-php.conf   0.0s
 => CACHED [19/47] RUN a2enconf docker-php                                                         0.0s
 => CACHED [20/47] COPY utils/apache2-foreground /usr/local/bin/                                   0.0s
 => CACHED [21/47] RUN sed -ri -e 's!/var/www/html!${ABSOLUTE_APACHE_DOCUMENT_ROOT}!g' /etc/apach  0.0s
 => CACHED [22/47] RUN sed -ri -e 's!/var/www/!${ABSOLUTE_APACHE_DOCUMENT_ROOT}!g' /etc/apache2/a  0.0s
 => CACHED [23/47] RUN rm /etc/php/8.0/apache2/php.ini                                             0.0s
 => CACHED [24/47] RUN a2enmod rewrite                                                             0.0s
 => CACHED [25/47] RUN chown docker:docker /var/www/html                                           0.0s
 => CACHED [26/47] WORKDIR /var/www/html                                                           0.0s
 => CACHED [27/47] RUN sed -i 's#/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin#/us  0.0s
 => CACHED [28/47] RUN mkdir ~/.ssh && touch ~/.ssh/known_hosts && chmod 644 ~/.ssh/known_hosts &  0.0s
 => CACHED [29/47] RUN echo 'eval "$(symfony-autocomplete)"' > ~/.bash_profile                     0.0s
 => CACHED [30/47] RUN {         echo "alias ls='ls --color=auto'";         echo "alias ll='ls --  0.0s
 => CACHED [31/47] RUN sed -i 's#/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin#/us  0.0s
 => CACHED [32/47] ADD https://github.com/krallin/tini/releases/download/v0.16.1/tini /tini        0.0s
 => CACHED [33/47] RUN chmod +x /tini                                                              0.0s
 => CACHED [34/47] COPY utils/generate_cron.php /usr/local/bin/generate_cron.php                   0.0s
 => CACHED [35/47] COPY utils/startup_commands.php /usr/local/bin/startup_commands.php             0.0s
 => CACHED [36/47] COPY utils/enable_apache_mods.php /usr/local/bin/enable_apache_mods.php         0.0s
 => CACHED [37/47] COPY utils/apache-expose-envvars.sh /usr/local/bin/apache-expose-envvars.sh     0.0s
 => CACHED [38/47] COPY utils/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh             0.0s
 => CACHED [39/47] COPY utils/docker-entrypoint-as-root.sh /usr/local/bin/docker-entrypoint-as-ro  0.0s
 => [40/47] COPY extensions/ /usr/local/lib/thecodingmachine-php/extensions                        0.3s
 => [41/47] RUN ln -s 8.0 /usr/local/lib/thecodingmachine-php/extensions/current                   0.2s
 => [42/47] RUN echo "ServerName localhost" > /etc/apache2/conf-available/servername.conf          0.8s
 => [43/47] RUN a2enconf servername                                                                0.5s
 => [44/47] RUN touch /etc/php/8.0/mods-available/generated_conf.ini && ln -s /etc/php/8.0/mods-a  0.5s
 => [45/47] RUN ln -s /etc/php/8.0/mods-available/generated_conf.ini /etc/php/8.0/apache2/conf.d/  0.5s
 => [46/47] COPY utils/install_selected_extensions.php /usr/local/bin/install_selected_extensions  0.0s
 => [47/47] COPY utils/install_selected_extensions.sh /usr/local/bin/install_selected_extensions.  0.0s
 => exporting to image                                                                             0.1s
 => => exporting layers                                                                            0.1s
 => => writing image sha256:74ca4ccd55da494303e9fa19b7500f99cb0d1d526c00a7aedccf39e1d4a93e20       0.0s
 => => naming to docker.io/thecodingmachine/php:8.0-v4-slim-apache                                 0.0s
[+] Building 10.6s (8/8) FINISHED                                                                       
 => [internal] load build definition from Dockerfile                                               0.0s
 => => transferring dockerfile: 38B                                                                0.0s
 => [internal] load .dockerignore                                                                  0.0s
 => => transferring context: 2B                                                                    0.0s
 => [internal] load metadata for docker.io/thecodingmachine/php:8.0-v4-slim-apache                 0.0s
 => [1/1] FROM docker.io/thecodingmachine/php:8.0-v4-slim-apache                                   0.1s
 => [2/1] RUN sudo -E PHP_EXTENSIONS="pdo_pgsql pdo_sqlite" /usr/local/bin/install_selected_exten  8.8s
 => [3/1] RUN if [ -n "$INSTALL_CRON" ]; then  SUPERCRONIC_URL=https://github.com/aptible/supercr  0.5s 
 => [4/1] RUN if [ -n "$NODE_VERSION" ]; then     sudo apt-get update &&     sudo apt-get install  0.8s 
 => exporting to image                                                                             0.3s 
 => => exporting layers                                                                            0.3s 
 => => writing image sha256:15e3df5826b7b18762621f8176da3a35f785f0049ce5452bd1a721ca7893573b       0.0s 
 => => naming to docker.io/test/slim_onbuild                                                       0.0s 
sockets
pdo_pgsql
pdo_sqlite
Untagged: test/slim_onbuild:latest
Deleted: sha256:15e3df5826b7b18762621f8176da3a35f785f0049ce5452bd1a721ca7893573b
[+] Building 11.8s (11/11) FINISHED                                                                     
 => [internal] load build definition from Dockerfile                                               0.0s
 => => transferring dockerfile: 38B                                                                0.0s
 => [internal] load .dockerignore                                                                  0.0s
 => => transferring context: 2B                                                                    0.0s
 => [internal] load metadata for docker.io/thecodingmachine/php:8.0-v4-slim-apache                 0.0s
 => CACHED [1/3] FROM docker.io/thecodingmachine/php:8.0-v4-slim-apache                            0.0s
 => [internal] load build context                                                                  0.0s
 => => transferring context: 34B                                                                   0.0s
 => [2/3] RUN sudo -E PHP_EXTENSIONS="gd" /usr/local/bin/install_selected_extensions.sh            9.0s
 => [3/3] RUN if [ -n "$INSTALL_CRON" ]; then  SUPERCRONIC_URL=https://github.com/aptible/supercr  0.6s 
 => [4/3] RUN if [ -n "$NODE_VERSION" ]; then     sudo apt-get update &&     sudo apt-get install  0.5s 
 => [5/3] COPY composer.json composer.json                                                         0.0s 
 => [6/3] RUN composer install                                                                     1.2s 
 => exporting to image                                                                             0.4s 
 => => exporting layers                                                                            0.4s 
 => => writing image sha256:6fc826f586f66f71b89ee9081ba990e501c326a611bf6ca397ba4dd68d4e9502       0.0s
 => => naming to docker.io/test/slim_onbuild_composer                                              0.0s
Untagged: test/slim_onbuild_composer:latest
Deleted: sha256:6fc826f586f66f71b89ee9081ba990e501c326a611bf6ca397ba4dd68d4e9502
total 8
drwxrwxr-x 2 1999 1999 4096 Mar  3 10:48 .
drwxrwxr-x 9 olly olly 4096 Mar  3 10:48 ..
TEST
total 12
drwxrwxr-x 2 www-data www-data 4096 Mar  3 10:48 .
drwxrwxr-x 9 olly     olly     4096 Mar  3 10:48 ..
-rw-rw-r-- 1 www-data www-data   61 Mar  3 10:48 composer.json
sudo: a terminal is required to read the password; either use the -S option to read from standard input or configure an askpass helper
Running 2.2.7 (2022-02-25 11:12:27) with PHP 8.0.16 on Linux / 5.13.0-30-generic
Reading ./composer.json (/var/www/html/composer.json)
Loading config file ./composer.json (/var/www/html/composer.json)
Checked CA file /etc/pki/tls/certs/ca-bundle.crt does not exist or it is not a file.
Checked directory /etc/pki/tls/certs/ca-bundle.crt does not exist or it is not a directory.
Checked CA file /etc/ssl/certs/ca-certificates.crt: valid
Executing command (/var/www/html): git branch -a --no-color --no-abbrev -v
Executing command (/var/www/html): git describe --exact-match --tags
Executing command (CWD): git --version
Executing command (/var/www/html): git log --pretty="%H" -n1 HEAD --no-show-signature
Executing command (/var/www/html): hg branch
Executing command (/var/www/html): fossil branch list
Executing command (/var/www/html): fossil tag list
Executing command (/var/www/html): svn info --xml
Failed to initialize global composer: Composer could not find the config file: /var/www/.composer/composer.json

Loading composer repositories with package information
Updating dependencies
Generating rules
Resolving dependencies through SAT
Looking at all rules.

Dependency resolution completed in 0.000 seconds
Analyzed 66 packages to resolve dependencies
Analyzed 66 rules to resolve dependencies
Nothing to modify in lock file
Writing lock file
Installing dependencies from lock file (including require-dev)
Reading ./composer.lock (/var/www/html/composer.lock)
Nothing to install, update or remove
Generating autoload files
mbstring
PDO
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100     3  100     3    0     0   3000      0 --:--:-- --:--:-- --:--:--  3000
06f7ecb151570d52d2c004823f6003382e65b5225ee2262521dcbc090df26702
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100     3  100     3    0     0   3000      0 --:--:-- --:--:-- --:--:--  3000
0ada351341cc7e74a39b61a554f3308377b64856926583d6e5c89dafa55dc11a
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100     3  100     3    0     0   3000      0 --:--:-- --:--:-- --:--:--  3000
c022746d5028492232d500bd4358f5bd18c951d62d9e3f2222429942f82e8df9
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100     3  100     3    0     0   3000      0 --:--:-- --:--:-- --:--:--  3000
d93f39b2d76d957d67889a16274186eae1ad4662c504d9d235e278436cbfb89c
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100     2  100     2    0     0    500      0 --:--:-- --:--:-- --:--:--   500
752c51ba6a36a2fc2bbe20add268942072ac9201aa8d67b327839826e2111eda
startup.sh executed
[+] Building 1025.0s (9/9) FINISHED                                                                     
 => [internal] load build definition from Dockerfile.apache                                        0.0s
 => => transferring dockerfile: 1.16kB                                                             0.0s
 => [internal] load .dockerignore                                                                  0.0s
 => => transferring context: 2B                                                                    0.0s
 => [internal] load metadata for docker.io/thecodingmachine/php:8.0-v4-slim-apache                 0.0s
 => CACHED [1/2] FROM docker.io/thecodingmachine/php:8.0-v4-slim-apache                            0.0s
 => [2/2] RUN sudo -E PHP_EXTENSIONS="" /usr/local/bin/install_selected_extensions.sh              6.3s
 => [3/2] RUN if [ -n "1" ]; then  SUPERCRONIC_URL=https://github.com/aptible/supercronic/release  3.5s
 => [4/2] RUN if [ -n "$NODE_VERSION" ]; then     sudo apt-get update &&     sudo apt-get install  0.4s 
 => [5/2] RUN cd /usr/local/lib/thecodingmachine-php/extensions/current/ && ./install_all.sh &  1013.2s 
 => exporting to image                                                                             1.4s 
 => => exporting layers                                                                            1.4s 
 => => writing image sha256:bd777883400559338f7aeac53015a3b7a865d671e265baeaaece39d679514d7c       0.0s 
 => => naming to docker.io/thecodingmachine/php:8.0-v4-apache                                      0.0s 
xdebug.client_host => 172.17.0.1 => 172.17.0.1                                                          
             Enabled Features (through 'xdebug.mode' setting)                                           
xdebug.mode => debug => debug
xdebug.mode => debug,coverage => debug,coverage
blackfire
blackfire
[+] Building 1.5s (8/8) FINISHED                                                                        
 => [internal] load build definition from Dockerfile                                               0.0s
 => => transferring dockerfile: 277B                                                               0.0s
 => [internal] load .dockerignore                                                                  0.0s
 => => transferring context: 2B                                                                    0.0s
 => [internal] load metadata for docker.io/thecodingmachine/php:8.0-v4-apache                      0.0s
 => [internal] load build context                                                                  0.0s
 => => transferring context: 81B                                                                   0.0s
 => [1/3] FROM docker.io/thecodingmachine/php:8.0-v4-apache                                        0.1s
 => [2/3] COPY composer.json composer.json                                                         0.0s
 => [3/3] RUN composer install                                                                     1.3s
 => exporting to image                                                                             0.0s
 => => exporting layers                                                                            0.0s
 => => writing image sha256:6381de4b93f31f4b462962164b4751d3ffa12cca07748377a6d047079777a581       0.0s
 => => naming to docker.io/test/composer_with_gd                                                   0.0s
Loading composer repositories with package information
Updating dependencies
Nothing to modify in lock file
Installing dependencies from lock file (including require-dev)
Nothing to install, update or remove
Generating autoload files
Untagged: test/composer_with_gd:latest
Deleted: sha256:6381de4b93f31f4b462962164b4751d3ffa12cca07748377a6d047079777a581
[+] Building 49.1s (6/6) FINISHED                                                                       
 => [internal] load build definition from Dockerfile.apache.node10                                 0.0s
 => => transferring dockerfile: 985B                                                               0.0s
 => [internal] load .dockerignore                                                                  0.0s
 => => transferring context: 2B                                                                    0.0s
 => [internal] load metadata for docker.io/thecodingmachine/php:8.0-v4-apache                      0.0s
 => CACHED [1/2] FROM docker.io/thecodingmachine/php:8.0-v4-apache                                 0.0s
 => [2/2] RUN apt-get update &&     apt-get install -y --no-install-recommends gnupg &&     curl  48.4s
 => exporting to image                                                                             0.7s
 => => exporting layers                                                                            0.6s
 => => writing image sha256:30096d1373ea04ac46ea74aff535eea4feaab9a8bee44e1f9c82340e06793f51       0.0s 
 => => naming to docker.io/thecodingmachine/php:8.0-v4-apache-node10                               0.0s 
[+] Building 31.1s (6/6) FINISHED                                                                       
 => [internal] load build definition from Dockerfile.apache.node12                                 0.0s 
 => => transferring dockerfile: 985B                                                               0.0s
 => [internal] load .dockerignore                                                                  0.0s
 => => transferring context: 2B                                                                    0.0s
 => [internal] load metadata for docker.io/thecodingmachine/php:8.0-v4-apache                      0.0s
 => CACHED [1/2] FROM docker.io/thecodingmachine/php:8.0-v4-apache                                 0.0s
 => [2/2] RUN apt-get update &&     apt-get install -y --no-install-recommends gnupg &&     curl  30.1s
 => exporting to image                                                                             0.9s
 => => exporting layers                                                                            0.6s
 => => writing image sha256:a3134de19910e8fb5063e0df5dc88db02a94731e62a699dcfb554e459147457e       0.0s 
 => => naming to docker.io/thecodingmachine/php:8.0-v4-apache-node12                               0.0s 
[+] Building 32.9s (6/6) FINISHED                                                                       
 => [internal] load build definition from Dockerfile.apache.node14                                 0.0s 
 => => transferring dockerfile: 985B                                                               0.0s
 => [internal] load .dockerignore                                                                  0.0s
 => => transferring context: 2B                                                                    0.0s
 => [internal] load metadata for docker.io/thecodingmachine/php:8.0-v4-apache                      0.0s
 => CACHED [1/2] FROM docker.io/thecodingmachine/php:8.0-v4-apache                                 0.0s
 => [2/2] RUN apt-get update &&     apt-get install -y --no-install-recommends gnupg &&     curl  32.1s
 => exporting to image                                                                             0.7s
 => => exporting layers                                                                            0.7s
 => => writing image sha256:876fdedb86b02b3f34eaffebca2fd1c9939e5a725e2aa219b646e8a61fc89a93       0.0s 
 => => naming to docker.io/thecodingmachine/php:8.0-v4-apache-node14                               0.0s 
[+] Building 29.8s (6/6) FINISHED                                                                       
 => [internal] load build definition from Dockerfile.apache.node16                                 0.0s 
 => => transferring dockerfile: 985B                                                               0.0s
 => [internal] load .dockerignore                                                                  0.0s
 => => transferring context: 2B                                                                    0.0s
 => [internal] load metadata for docker.io/thecodingmachine/php:8.0-v4-apache                      0.0s
 => CACHED [1/2] FROM docker.io/thecodingmachine/php:8.0-v4-apache                                 0.0s
 => [2/2] RUN apt-get update &&     apt-get install -y --no-install-recommends gnupg &&     curl  28.9s
 => exporting to image                                                                             0.9s
 => => exporting layers                                                                            0.7s
 => => writing image sha256:9952fd6a5925e37f0b3c3001acdf640d710dc59a8f29c46bb1f8f4dc2e3e0cc0       0.0s 
 => => naming to docker.io/thecodingmachine/php:8.0-v4-apache-node16                               0.0s 
Tests passed with success     
```

```
# PHP_VERSION=7.4 BRANCH=v4 VARIANT=fpm ./build-and-test.sh
[+] Building 22.9s (46/46) FINISHED                                                                     
 => [internal] load build definition from Dockerfile.slim.fpm                                      0.0s
 => => transferring dockerfile: 12.40kB                                                            0.0s
 => [internal] load .dockerignore                                                                  0.0s
 => => transferring context: 2B                                                                    0.0s
 => [internal] load metadata for docker.io/library/ubuntu:20.04                                    0.0s
 => [internal] load build context                                                                  0.0s
 => => transferring context: 19.08kB                                                               0.0s
 => CACHED https://github.com/krallin/tini/releases/download/v0.16.1/tini                          0.0s
 => [ 1/40] FROM docker.io/library/ubuntu:20.04                                                    0.0s
 => CACHED [ 2/40] RUN apt-get update     && apt-get install -y --no-install-recommends gnupg      0.0s
 => CACHED [ 3/40] RUN useradd -ms /bin/bash docker && adduser docker sudo                         0.0s
 => CACHED [ 4/40] RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers                         0.0s
 => CACHED [ 5/40] RUN cp /usr/lib/php/7.4/php.ini-development /usr/lib/php/7.4/php.ini-developme  0.0s
 => CACHED [ 6/40] RUN rm /etc/php/7.4/cli/php.ini                                                 0.0s
 => CACHED [ 7/40] RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/loc  0.0s
 => CACHED [ 8/40] COPY utils/utils.php /usr/local/bin/utils.php                                   0.0s
 => CACHED [ 9/40] RUN mv /usr/bin/php /usr/bin/real_php                                           0.0s
 => CACHED [10/40] COPY utils/php_proxy.sh /usr/bin/php                                            0.0s
 => CACHED [11/40] COPY utils/check_php_env_var_changes.php /usr/local/bin/check_php_env_var_chan  0.0s
 => CACHED [12/40] COPY utils/php_env_var_cache.php /opt/php_env_var_cache.php                     0.0s
 => CACHED [13/40] COPY utils/generate_conf.php /usr/local/bin/generate_conf.php                   0.0s
 => CACHED [14/40] COPY utils/setup_extensions.php /usr/local/bin/setup_extensions.php             0.0s
 => CACHED [15/40] RUN composer global require bamarni/symfony-console-autocomplete &&     rm -rf  0.0s
 => [16/40] RUN apt-get update     && apt-get install -y --no-install-recommends php7.4-fpm       16.2s
 => [17/40] RUN rm /etc/php/7.4/fpm/php.ini                                                        0.5s
 => [18/40] RUN ln -s /usr/sbin/php-fpm7.4 /usr/sbin/php-fpm                                       0.4s 
 => [19/40] COPY utils/fpm-docker.conf /etc/php/7.4/fpm/pool.d/docker.conf                         0.0s 
 => [20/40] COPY utils/fpm-zz-docker.conf /etc/php/7.4/fpm/pool.d/zz-docker.conf                   0.0s 
 => [21/40] RUN mkdir -p /var/www/html && chown -R docker: /var/www                                0.7s 
 => [22/40] RUN chown docker:docker /var/www/html                                                  0.5s 
 => [23/40] WORKDIR /var/www/html                                                                  0.0s
 => [24/40] RUN sed -i 's#/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin#/usr/local  0.5s
 => [25/40] RUN mkdir ~/.ssh && touch ~/.ssh/known_hosts && chmod 644 ~/.ssh/known_hosts && eval   0.5s
 => [26/40] RUN echo 'eval "$(symfony-autocomplete)"' > ~/.bash_profile                            0.4s
 => [27/40] RUN {         echo "alias ls='ls --color=auto'";         echo "alias ll='ls --color=a  0.5s
 => [28/40] RUN sed -i 's#/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin#/usr/local  0.4s
 => [29/40] ADD https://github.com/krallin/tini/releases/download/v0.16.1/tini /tini               0.0s
 => [30/40] RUN chmod +x /tini                                                                     0.5s
 => [31/40] COPY utils/generate_cron.php /usr/local/bin/generate_cron.php                          0.0s
 => [32/40] COPY utils/startup_commands.php /usr/local/bin/startup_commands.php                    0.0s
 => [33/40] COPY utils/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh                    0.0s
 => [34/40] COPY utils/docker-entrypoint-as-root.sh /usr/local/bin/docker-entrypoint-as-root.sh    0.0s
 => [35/40] COPY extensions/ /usr/local/lib/thecodingmachine-php/extensions                        0.0s
 => [36/40] RUN ln -s 7.4 /usr/local/lib/thecodingmachine-php/extensions/current                   0.4s
 => [37/40] RUN touch /etc/php/7.4/mods-available/generated_conf.ini && ln -s /etc/php/7.4/mods-a  0.5s
 => [38/40] RUN ln -s /etc/php/7.4/mods-available/generated_conf.ini /etc/php/7.4/fpm/conf.d/gene  0.5s
 => [39/40] COPY utils/install_selected_extensions.php /usr/local/bin/install_selected_extensions  0.0s
 => [40/40] COPY utils/install_selected_extensions.sh /usr/local/bin/install_selected_extensions.  0.0s
 => exporting to image                                                                             0.3s
 => => exporting layers                                                                            0.3s
 => => writing image sha256:e482bffe19a11d151227612953e656e5f3bd53b09882a3c0da7aac9cd37142a8       0.0s
 => => naming to docker.io/thecodingmachine/php:7.4-v4-slim-fpm                                    0.0s
[+] Building 11.1s (8/8) FINISHED                                                                       
 => [internal] load build definition from Dockerfile                                               0.0s
 => => transferring dockerfile: 38B                                                                0.0s
 => [internal] load .dockerignore                                                                  0.0s
 => => transferring context: 2B                                                                    0.0s
 => [internal] load metadata for docker.io/thecodingmachine/php:7.4-v4-slim-fpm                    0.0s
 => [1/1] FROM docker.io/thecodingmachine/php:7.4-v4-slim-fpm                                      0.2s
 => [2/1] RUN sudo -E PHP_EXTENSIONS="pdo_pgsql pdo_sqlite" /usr/local/bin/install_selected_exten  9.6s
 => [3/1] RUN if [ -n "$INSTALL_CRON" ]; then  SUPERCRONIC_URL=https://github.com/aptible/supercr  0.5s
 => [4/1] RUN if [ -n "$NODE_VERSION" ]; then     sudo apt-get update &&     sudo apt-get install  0.5s 
 => exporting to image                                                                             0.3s 
 => => exporting layers                                                                            0.3s 
 => => writing image sha256:6f9942c624d17df257a17832ad4ee42ae0d4309bf72c391e3435fc10de3c3943       0.0s 
 => => naming to docker.io/test/slim_onbuild                                                       0.0s 
sockets
pdo_pgsql
pdo_sqlite
Untagged: test/slim_onbuild:latest
Deleted: sha256:6f9942c624d17df257a17832ad4ee42ae0d4309bf72c391e3435fc10de3c3943
[+] Building 12.1s (11/11) FINISHED                                                                     
 => [internal] load build definition from Dockerfile                                               0.0s
 => => transferring dockerfile: 38B                                                                0.0s
 => [internal] load .dockerignore                                                                  0.0s
 => => transferring context: 2B                                                                    0.0s
 => [internal] load metadata for docker.io/thecodingmachine/php:7.4-v4-slim-fpm                    0.0s
 => CACHED [1/3] FROM docker.io/thecodingmachine/php:7.4-v4-slim-fpm                               0.0s
 => [internal] load build context                                                                  0.0s
 => => transferring context: 34B                                                                   0.0s
 => [2/3] RUN sudo -E PHP_EXTENSIONS="gd" /usr/local/bin/install_selected_extensions.sh            9.1s
 => [3/3] RUN if [ -n "$INSTALL_CRON" ]; then  SUPERCRONIC_URL=https://github.com/aptible/supercr  0.6s
 => [4/3] RUN if [ -n "$NODE_VERSION" ]; then     sudo apt-get update &&     sudo apt-get install  0.5s 
 => [5/3] COPY composer.json composer.json                                                         0.0s 
 => [6/3] RUN composer install                                                                     1.3s 
 => exporting to image                                                                             0.4s 
 => => exporting layers                                                                            0.4s 
 => => writing image sha256:c6c9f3d78e44fd7fd312a767525bfc41fb330be1a1128571e6f22fffe117e2a2       0.0s
 => => naming to docker.io/test/slim_onbuild_composer                                              0.0s
Untagged: test/slim_onbuild_composer:latest
Deleted: sha256:c6c9f3d78e44fd7fd312a767525bfc41fb330be1a1128571e6f22fffe117e2a2
total 8
drwxrwxr-x 2 1999 1999 4096 Mar  3 11:12 .
drwxrwxr-x 9 olly olly 4096 Mar  3 11:12 ..
TEST
total 12
drwxrwxr-x 2 www-data www-data 4096 Mar  3 11:12 .
drwxrwxr-x 9 olly     olly     4096 Mar  3 11:12 ..
-rw-rw-r-- 1 www-data www-data   61 Mar  3 11:12 composer.json
sudo: a terminal is required to read the password; either use the -S option to read from standard input or configure an askpass helper
Running 2.2.6 (2022-02-04 17:00:38) with PHP 7.4.28 on Linux / 5.13.0-30-generic
Reading ./composer.json (/var/www/html/composer.json)
Loading config file ./composer.json (/var/www/html/composer.json)
Checked CA file /etc/pki/tls/certs/ca-bundle.crt does not exist or it is not a file.
Checked directory /etc/pki/tls/certs/ca-bundle.crt does not exist or it is not a directory.
Checked CA file /etc/ssl/certs/ca-certificates.crt: valid
Executing command (/var/www/html): git branch -a --no-color --no-abbrev -v
Executing command (/var/www/html): git describe --exact-match --tags
Executing command (CWD): git --version
Executing command (/var/www/html): git log --pretty="%H" -n1 HEAD --no-show-signature
Executing command (/var/www/html): hg branch
Executing command (/var/www/html): fossil branch list
Executing command (/var/www/html): fossil tag list
Executing command (/var/www/html): svn info --xml
Failed to initialize global composer: Composer could not find the config file: /var/www/.config/composer/composer.json

Loading composer repositories with package information
Updating dependencies
Generating rules
Resolving dependencies through SAT
Looking at all rules.

Dependency resolution completed in 0.000 seconds
Analyzed 66 packages to resolve dependencies
Analyzed 66 rules to resolve dependencies
Nothing to modify in lock file
Writing lock file
Installing dependencies from lock file (including require-dev)
Reading ./composer.lock (/var/www/html/composer.lock)
Nothing to install, update or remove
Generating autoload files
mbstring
PDO
ece58aff801ef9f8e2bcdda64df413d2802436457a7dfacdf7e8ea95df9a5010
startup.sh executed
[+] Building 1045.7s (9/9) FINISHED                                                                     
 => [internal] load build definition from Dockerfile.fpm                                           0.0s
 => => transferring dockerfile: 1.16kB                                                             0.0s
 => [internal] load .dockerignore                                                                  0.0s
 => => transferring context: 2B                                                                    0.0s
 => [internal] load metadata for docker.io/thecodingmachine/php:7.4-v4-slim-fpm                    0.0s
 => CACHED [1/2] FROM docker.io/thecodingmachine/php:7.4-v4-slim-fpm                               0.0s
 => [2/2] RUN sudo -E PHP_EXTENSIONS="" /usr/local/bin/install_selected_extensions.sh              6.7s
 => [3/2] RUN if [ -n "1" ]; then  SUPERCRONIC_URL=https://github.com/aptible/supercronic/release  3.1s
 => [4/2] RUN if [ -n "$NODE_VERSION" ]; then     sudo apt-get update &&     sudo apt-get install  0.5s 
 => [5/2] RUN cd /usr/local/lib/thecodingmachine-php/extensions/current/ && ./install_all.sh &  1033.8s 
 => exporting to image                                                                             1.7s 
 => => exporting layers                                                                            1.7s 
 => => writing image sha256:571c9f0bbfbeb8c25a6cb95f08e1538aea795969245b02e9313972d63b40421a       0.0s 
 => => naming to docker.io/thecodingmachine/php:7.4-v4-fpm                                         0.0s 
xdebug.client_host => 172.17.0.1 => 172.17.0.1                                                          
             Enabled Features (through 'xdebug.mode' setting)                                           
xdebug.mode => debug => debug
xdebug.mode => debug,coverage => debug,coverage
blackfire
blackfire
[+] Building 2.3s (8/8) FINISHED                                                                        
 => [internal] load build definition from Dockerfile                                               0.0s
 => => transferring dockerfile: 38B                                                                0.0s
 => [internal] load .dockerignore                                                                  0.0s
 => => transferring context: 2B                                                                    0.0s
 => [internal] load metadata for docker.io/thecodingmachine/php:7.4-v4-fpm                         0.0s
 => [internal] load build context                                                                  0.0s
 => => transferring context: 34B                                                                   0.0s
 => [1/3] FROM docker.io/thecodingmachine/php:7.4-v4-fpm                                           0.1s
 => [2/3] COPY composer.json composer.json                                                         0.0s
 => [3/3] RUN composer install                                                                     2.0s
 => exporting to image                                                                             0.1s 
 => => exporting layers                                                                            0.0s 
 => => writing image sha256:bc7c1563d9e24cc7f8c862ee09479dfd57da6b1e7dae3cc672180c162aaec291       0.0s 
 => => naming to docker.io/test/composer_with_gd                                                   0.0s 
Loading composer repositories with package information                                                  
Updating dependencies                                                                                   
Nothing to modify in lock file
Installing dependencies from lock file (including require-dev)
Nothing to install, update or remove
Generating autoload files
Untagged: test/composer_with_gd:latest
Deleted: sha256:bc7c1563d9e24cc7f8c862ee09479dfd57da6b1e7dae3cc672180c162aaec291
[+] Building 47.5s (6/6) FINISHED                                                                       
 => [internal] load build definition from Dockerfile.fpm.node10                                    0.0s
 => => transferring dockerfile: 979B                                                               0.0s
 => [internal] load .dockerignore                                                                  0.0s
 => => transferring context: 2B                                                                    0.0s
 => [internal] load metadata for docker.io/thecodingmachine/php:7.4-v4-fpm                         0.0s
 => CACHED [1/2] FROM docker.io/thecodingmachine/php:7.4-v4-fpm                                    0.0s
 => [2/2] RUN apt-get update &&     apt-get install -y --no-install-recommends gnupg &&     curl  46.9s
 => exporting to image                                                                             0.6s
 => => exporting layers                                                                            0.5s
 => => writing image sha256:8aadabd24dab5afa0d21356227bf1f0e30f18a8c079f2191dfc1689e754fe44d       0.0s 
 => => naming to docker.io/thecodingmachine/php:7.4-v4-fpm-node10                                  0.0s 
[+] Building 29.9s (6/6) FINISHED                                                                       
 => [internal] load build definition from Dockerfile.fpm.node12                                    0.0s 
 => => transferring dockerfile: 979B                                                               0.0s
 => [internal] load .dockerignore                                                                  0.0s
 => => transferring context: 2B                                                                    0.0s
 => [internal] load metadata for docker.io/thecodingmachine/php:7.4-v4-fpm                         0.0s
 => CACHED [1/2] FROM docker.io/thecodingmachine/php:7.4-v4-fpm                                    0.0s
 => [2/2] RUN apt-get update &&     apt-get install -y --no-install-recommends gnupg &&     curl  29.2s
 => exporting to image                                                                             0.6s
 => => exporting layers                                                                            0.6s
 => => writing image sha256:60b3f8cb60df6f04b1ba1ed426d9d71046ab6a4b9c094b693d0c88b9251020a9       0.0s 
 => => naming to docker.io/thecodingmachine/php:7.4-v4-fpm-node12                                  0.0s 
[+] Building 31.8s (6/6) FINISHED                                                                       
 => [internal] load build definition from Dockerfile.fpm.node14                                    0.0s 
 => => transferring dockerfile: 979B                                                               0.0s
 => [internal] load .dockerignore                                                                  0.0s
 => => transferring context: 2B                                                                    0.0s
 => [internal] load metadata for docker.io/thecodingmachine/php:7.4-v4-fpm                         0.0s
 => CACHED [1/2] FROM docker.io/thecodingmachine/php:7.4-v4-fpm                                    0.0s
 => [2/2] RUN apt-get update &&     apt-get install -y --no-install-recommends gnupg &&     curl  31.1s
 => exporting to image                                                                             0.7s
 => => exporting layers                                                                            0.7s
 => => writing image sha256:7caa8ad16a0aa6fd5e34017938bdf5526b69c9a6902f86e18516e8a920607fe5       0.0s 
 => => naming to docker.io/thecodingmachine/php:7.4-v4-fpm-node14                                  0.0s 
[+] Building 29.2s (6/6) FINISHED                                                                       
 => [internal] load build definition from Dockerfile.fpm.node16                                    0.0s 
 => => transferring dockerfile: 979B                                                               0.0s
 => [internal] load .dockerignore                                                                  0.0s
 => => transferring context: 2B                                                                    0.0s
 => [internal] load metadata for docker.io/thecodingmachine/php:7.4-v4-fpm                         0.0s
 => CACHED [1/2] FROM docker.io/thecodingmachine/php:7.4-v4-fpm                                    0.0s
 => [2/2] RUN apt-get update &&     apt-get install -y --no-install-recommends gnupg &&     curl  28.5s
 => exporting to image                                                                             0.7s
 => => exporting layers                                                                            0.7s
 => => writing image sha256:7f4eb4406c5f4bbf7dcf116415a4f7b98661ba6f2a8b800232d969122c2b98dc       0.0s 
 => => naming to docker.io/thecodingmachine/php:7.4-v4-fpm-node16                                  0.0s 
Tests passed with success          
```

```
PHP_VERSION=8.1 BRANCH=v4 VARIANT=cli ./build-and-test.sh
[+] Building 72.7s (39/39) FINISHED                                                                     
 => [internal] load build definition from Dockerfile.slim.cli                                      0.0s
 => => transferring dockerfile: 10.93kB                                                            0.0s
 => [internal] load .dockerignore                                                                  0.0s
 => => transferring context: 2B                                                                    0.0s
 => [internal] load metadata for docker.io/library/ubuntu:20.04                                    0.0s
 => [internal] load build context                                                                  0.0s
 => => transferring context: 18.57kB                                                               0.0s
 => CACHED https://github.com/krallin/tini/releases/download/v0.16.1/tini                          0.0s
 => CACHED [ 1/33] FROM docker.io/library/ubuntu:20.04                                             0.0s
 => [ 2/33] RUN apt-get update     && apt-get install -y --no-install-recommends gnupg     && ec  30.7s
 => [ 3/33] RUN useradd -ms /bin/bash docker && adduser docker sudo                                0.6s 
 => [ 4/33] RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers                                0.5s 
 => [ 5/33] RUN cp /usr/lib/php/8.1/php.ini-development /usr/lib/php/8.1/php.ini-development.cli   0.5s 
 => [ 6/33] RUN rm /etc/php/8.1/cli/php.ini                                                        0.5s 
 => [ 7/33] RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin   1.0s 
 => [ 8/33] COPY utils/utils.php /usr/local/bin/utils.php                                          0.0s 
 => [ 9/33] RUN mv /usr/bin/php /usr/bin/real_php                                                  0.4s
 => [10/33] COPY utils/php_proxy.sh /usr/bin/php                                                   0.0s 
 => [11/33] COPY utils/check_php_env_var_changes.php /usr/local/bin/check_php_env_var_changes.php  0.0s 
 => [12/33] COPY utils/php_env_var_cache.php /opt/php_env_var_cache.php                            0.0s
 => [13/33] COPY utils/generate_conf.php /usr/local/bin/generate_conf.php                          0.0s
 => [14/33] COPY utils/setup_extensions.php /usr/local/bin/setup_extensions.php                    0.0s
 => [15/33] RUN composer global require bamarni/symfony-console-autocomplete &&     rm -rf ~/.co  32.3s
 => [16/33] RUN mkdir -p /usr/src/app && chown docker:docker /usr/src/app                          1.1s 
 => [17/33] WORKDIR /usr/src/app                                                                   0.0s 
 => [18/33] RUN sed -i 's#/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin#/usr/local  0.5s 
 => [19/33] RUN mkdir ~/.ssh && touch ~/.ssh/known_hosts && chmod 644 ~/.ssh/known_hosts && eval   0.5s 
 => [20/33] RUN echo 'eval "$(symfony-autocomplete)"' > ~/.bash_profile                            0.5s 
 => [21/33] RUN {         echo "alias ls='ls --color=auto'";         echo "alias ll='ls --color=a  0.5s 
 => [22/33] RUN sed -i 's#/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin#/usr/local  0.5s
 => [23/33] ADD https://github.com/krallin/tini/releases/download/v0.16.1/tini /tini               0.0s
 => [24/33] RUN chmod +x /tini                                                                     0.4s
 => [25/33] COPY utils/generate_cron.php /usr/local/bin/generate_cron.php                          0.0s
 => [26/33] COPY utils/startup_commands.php /usr/local/bin/startup_commands.php                    0.0s
 => [27/33] COPY utils/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh                    0.0s
 => [28/33] COPY utils/docker-entrypoint-as-root.sh /usr/local/bin/docker-entrypoint-as-root.sh    0.1s
 => [29/33] COPY extensions/ /usr/local/lib/thecodingmachine-php/extensions                        0.0s
 => [30/33] RUN ln -s 8.1 /usr/local/lib/thecodingmachine-php/extensions/current                   0.3s
 => [31/33] RUN touch /etc/php/8.1/mods-available/generated_conf.ini && ln -s /etc/php/8.1/mods-a  0.4s
 => [32/33] COPY utils/install_selected_extensions.php /usr/local/bin/install_selected_extensions  0.0s
 => [33/33] COPY utils/install_selected_extensions.sh /usr/local/bin/install_selected_extensions.  0.0s
 => exporting to image                                                                             1.1s
 => => exporting layers                                                                            1.1s
 => => writing image sha256:b69d97488fefb7c159e2f385379586d57cc207b8da9e224c220c7a28aaef6d82       0.0s
 => => naming to docker.io/thecodingmachine/php:8.1-v4-slim-cli                                    0.0s
[+] Building 11.0s (8/8) FINISHED                                                                       
 => [internal] load build definition from Dockerfile                                               0.0s
 => => transferring dockerfile: 38B                                                                0.0s
 => [internal] load .dockerignore                                                                  0.0s
 => => transferring context: 2B                                                                    0.0s
 => [internal] load metadata for docker.io/thecodingmachine/php:8.1-v4-slim-cli                    0.0s
 => [1/1] FROM docker.io/thecodingmachine/php:8.1-v4-slim-cli                                      0.2s
 => [2/1] RUN sudo -E PHP_EXTENSIONS="pdo_pgsql pdo_sqlite" /usr/local/bin/install_selected_exten  9.4s
 => [3/1] RUN if [ -n "$INSTALL_CRON" ]; then  SUPERCRONIC_URL=https://github.com/aptible/supercr  0.5s
 => [4/1] RUN if [ -n "$NODE_VERSION" ]; then     sudo apt-get update &&     sudo apt-get install  0.5s 
 => exporting to image                                                                             0.3s 
 => => exporting layers                                                                            0.3s 
 => => writing image sha256:bd19f51cc28b11871784752bad8e6c0c23eea0c2b9e49e6792775f6f7977b2a7       0.0s 
 => => naming to docker.io/test/slim_onbuild                                                       0.0s 
sockets
pdo_pgsql
pdo_sqlite
Untagged: test/slim_onbuild:latest
Deleted: sha256:bd19f51cc28b11871784752bad8e6c0c23eea0c2b9e49e6792775f6f7977b2a7
[+] Building 10.7s (11/11) FINISHED                                                                     
 => [internal] load build definition from Dockerfile                                               0.0s
 => => transferring dockerfile: 38B                                                                0.0s
 => [internal] load .dockerignore                                                                  0.0s
 => => transferring context: 2B                                                                    0.0s
 => [internal] load metadata for docker.io/thecodingmachine/php:8.1-v4-slim-cli                    0.0s
 => CACHED [1/3] FROM docker.io/thecodingmachine/php:8.1-v4-slim-cli                               0.0s
 => [internal] load build context                                                                  0.0s
 => => transferring context: 34B                                                                   0.0s
 => [2/3] RUN sudo -E PHP_EXTENSIONS="gd" /usr/local/bin/install_selected_extensions.sh            8.5s
 => [3/3] RUN if [ -n "$INSTALL_CRON" ]; then  SUPERCRONIC_URL=https://github.com/aptible/supercr  0.5s
 => [4/3] RUN if [ -n "$NODE_VERSION" ]; then     sudo apt-get update &&     sudo apt-get install  0.5s 
 => [5/3] COPY composer.json composer.json                                                         0.0s 
 => [6/3] RUN composer install                                                                     0.8s 
 => exporting to image                                                                             0.4s 
 => => exporting layers                                                                            0.4s 
 => => writing image sha256:cb89156196aafec07be59711620921c3eabb42be29426c9f0a6610ab0f20b9ee       0.0s
 => => naming to docker.io/test/slim_onbuild_composer                                              0.0s
Untagged: test/slim_onbuild_composer:latest
Deleted: sha256:cb89156196aafec07be59711620921c3eabb42be29426c9f0a6610ab0f20b9ee
total 8
drwxrwxr-x 2 1999 1999 4096 Mar  3 11:36 .
drwxrwxr-x 9 olly olly 4096 Mar  3 11:36 ..
TEST
total 12
drwxrwxr-x 2 www-data www-data 4096 Mar  3 11:36 .
drwxrwxr-x 9 olly     olly     4096 Mar  3 11:36 ..
-rw-rw-r-- 1 www-data www-data   61 Mar  3 11:36 composer.json
sudo: a terminal is required to read the password; either use the -S option to read from standard input or configure an askpass helper
Running 2.2.7 (2022-02-25 11:12:27) with PHP 8.1.3 on Linux / 5.13.0-30-generic
Reading ./composer.json (/usr/src/app/composer.json)
Loading config file ./composer.json (/usr/src/app/composer.json)
Checked CA file /etc/pki/tls/certs/ca-bundle.crt does not exist or it is not a file.
Checked directory /etc/pki/tls/certs/ca-bundle.crt does not exist or it is not a directory.
Checked CA file /etc/ssl/certs/ca-certificates.crt: valid
Executing command (/usr/src/app): git branch -a --no-color --no-abbrev -v
Executing command (/usr/src/app): git describe --exact-match --tags
Executing command (CWD): git --version
Executing command (/usr/src/app): git log --pretty="%H" -n1 HEAD --no-show-signature
Executing command (/usr/src/app): hg branch
Executing command (/usr/src/app): fossil branch list
Executing command (/usr/src/app): fossil tag list
Executing command (/usr/src/app): svn info --xml
Failed to initialize global composer: Composer could not find the config file: /var/www/.composer/composer.json

Loading composer repositories with package information
Updating dependencies
Generating rules
Resolving dependencies through SAT
Looking at all rules.

Dependency resolution completed in 0.000 seconds
Analyzed 66 packages to resolve dependencies
Analyzed 66 rules to resolve dependencies
Nothing to modify in lock file
Writing lock file
Installing dependencies from lock file (including require-dev)
Reading ./composer.lock (/usr/src/app/composer.lock)
Nothing to install, update or remove
Generating autoload files
mbstring
PDO
startup.sh executed
[+] Building 850.9s (9/9) FINISHED                                                                      
 => [internal] load build definition from Dockerfile.cli                                           0.0s
 => => transferring dockerfile: 1.16kB                                                             0.0s
 => [internal] load .dockerignore                                                                  0.0s
 => => transferring context: 2B                                                                    0.0s
 => [internal] load metadata for docker.io/thecodingmachine/php:8.1-v4-slim-cli                    0.0s
 => CACHED [1/2] FROM docker.io/thecodingmachine/php:8.1-v4-slim-cli                               0.0s
 => [2/2] RUN sudo -E PHP_EXTENSIONS="" /usr/local/bin/install_selected_extensions.sh              6.4s
 => [3/2] RUN if [ -n "1" ]; then  SUPERCRONIC_URL=https://github.com/aptible/supercronic/release  3.1s
 => [4/2] RUN if [ -n "$NODE_VERSION" ]; then     sudo apt-get update &&     sudo apt-get install  0.4s 
 => [5/2] RUN cd /usr/local/lib/thecodingmachine-php/extensions/current/ && ./install_all.sh &&  839.4s 
 => exporting to image                                                                             1.5s 
 => => exporting layers                                                                            1.4s 
 => => writing image sha256:f5543c1184f3815c696002e0c8be8bdd78548fe65dda003ac8cfd6cf9fa2cbbe       0.0s 
 => => naming to docker.io/thecodingmachine/php:8.1-v4-cli                                         0.0s 
xdebug.client_host => 172.17.0.1 => 172.17.0.1                                                          
             Enabled Features (through 'xdebug.mode' setting)                                           
xdebug.mode => debug => debug
xdebug.mode => debug,coverage => debug,coverage
[+] Building 1.1s (8/8) FINISHED                                                                        
 => [internal] load build definition from Dockerfile                                               0.0s
 => => transferring dockerfile: 38B                                                                0.0s
 => [internal] load .dockerignore                                                                  0.0s
 => => transferring context: 2B                                                                    0.0s
 => [internal] load metadata for docker.io/thecodingmachine/php:8.1-v4-cli                         0.0s
 => [internal] load build context                                                                  0.0s
 => => transferring context: 34B                                                                   0.0s
 => [1/3] FROM docker.io/thecodingmachine/php:8.1-v4-cli                                           0.1s
 => [2/3] COPY composer.json composer.json                                                         0.0s
 => [3/3] RUN composer install                                                                     1.0s
 => exporting to image                                                                             0.0s
 => => exporting layers                                                                            0.0s
 => => writing image sha256:c498bdd61a6a09da6de49a68e6d02b9144f184cf7e160ca611fcb067b4ab5bbf       0.0s
 => => naming to docker.io/test/composer_with_gd                                                   0.0s
Loading composer repositories with package information
Updating dependencies
Nothing to modify in lock file
Installing dependencies from lock file (including require-dev)
Nothing to install, update or remove
Generating autoload files
Untagged: test/composer_with_gd:latest
Deleted: sha256:c498bdd61a6a09da6de49a68e6d02b9144f184cf7e160ca611fcb067b4ab5bbf
[+] Building 48.0s (6/6) FINISHED                                                                       
 => [internal] load build definition from Dockerfile.cli.node10                                    0.0s
 => => transferring dockerfile: 979B                                                               0.0s
 => [internal] load .dockerignore                                                                  0.0s
 => => transferring context: 2B                                                                    0.0s
 => [internal] load metadata for docker.io/thecodingmachine/php:8.1-v4-cli                         0.0s
 => CACHED [1/2] FROM docker.io/thecodingmachine/php:8.1-v4-cli                                    0.0s
 => [2/2] RUN apt-get update &&     apt-get install -y --no-install-recommends gnupg &&     curl  47.4s
 => exporting to image                                                                             0.6s
 => => exporting layers                                                                            0.5s
 => => writing image sha256:498e7ad1de6c12179b2c92662b12aa73b5d6982d9c51426553b6973a572f7c6d       0.0s 
 => => naming to docker.io/thecodingmachine/php:8.1-v4-cli-node10                                  0.0s 
[+] Building 29.9s (6/6) FINISHED                                                                       
 => [internal] load build definition from Dockerfile.cli.node12                                    0.0s 
 => => transferring dockerfile: 979B                                                               0.0s
 => [internal] load .dockerignore                                                                  0.0s
 => => transferring context: 2B                                                                    0.0s
 => [internal] load metadata for docker.io/thecodingmachine/php:8.1-v4-cli                         0.0s
 => CACHED [1/2] FROM docker.io/thecodingmachine/php:8.1-v4-cli                                    0.0s
 => [2/2] RUN apt-get update &&     apt-get install -y --no-install-recommends gnupg &&     curl  29.3s
 => exporting to image                                                                             0.6s
 => => exporting layers                                                                            0.6s
 => => writing image sha256:17c8988883b76a1e22c4c7de82f49fcc86f8afd1167760229d5f129d225dc716       0.0s 
 => => naming to docker.io/thecodingmachine/php:8.1-v4-cli-node12                                  0.0s 
[+] Building 31.6s (6/6) FINISHED                                                                       
 => [internal] load build definition from Dockerfile.cli.node14                                    0.0s 
 => => transferring dockerfile: 979B                                                               0.0s
 => [internal] load .dockerignore                                                                  0.0s
 => => transferring context: 2B                                                                    0.0s
 => [internal] load metadata for docker.io/thecodingmachine/php:8.1-v4-cli                         0.0s
 => CACHED [1/2] FROM docker.io/thecodingmachine/php:8.1-v4-cli                                    0.0s
 => [2/2] RUN apt-get update &&     apt-get install -y --no-install-recommends gnupg &&     curl  30.9s
 => exporting to image                                                                             0.7s
 => => exporting layers                                                                            0.7s
 => => writing image sha256:8f1de4d692395b6054af7b36228dbe9762b3b5e662b656b72633510661f90b33       0.0s 
 => => naming to docker.io/thecodingmachine/php:8.1-v4-cli-node14                                  0.0s 
[+] Building 29.1s (6/6) FINISHED                                                                       
 => [internal] load build definition from Dockerfile.cli.node16                                    0.0s 
 => => transferring dockerfile: 979B                                                               0.0s
 => [internal] load .dockerignore                                                                  0.0s
 => => transferring context: 2B                                                                    0.0s
 => [internal] load metadata for docker.io/thecodingmachine/php:8.1-v4-cli                         0.0s
 => CACHED [1/2] FROM docker.io/thecodingmachine/php:8.1-v4-cli                                    0.0s
 => [2/2] RUN apt-get update &&     apt-get install -y --no-install-recommends gnupg &&     curl  28.3s
 => exporting to image                                                                             0.7s
 => => exporting layers                                                                            0.7s
 => => writing image sha256:ce83ac391d4f4adfce7a9f4cf5fd2acf2e2bfdebf84b16bf37bf4765469953cf       0.0s 
 => => naming to docker.io/thecodingmachine/php:8.1-v4-cli-node16                                  0.0s 
Tests passed with success  
```