### PR TITLE
Use NPM 6.x on Node 10.x

### DIFF
--- a/Dockerfile.apache.node10
+++ b/Dockerfile.apache.node10
@@ -16,7 +16,7 @@ RUN apt-get update && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
     apt-get update && \
     apt-get install -y --no-install-recommends yarn && \
-    npm install -g npm && \
+    npm install -g npm@^6.14 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
 

--- a/Dockerfile.cli.node10
+++ b/Dockerfile.cli.node10
@@ -16,7 +16,7 @@ RUN apt-get update && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
     apt-get update && \
     apt-get install -y --no-install-recommends yarn && \
-    npm install -g npm && \
+    npm install -g npm@^6.14 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
 

--- a/Dockerfile.fpm.node10
+++ b/Dockerfile.fpm.node10
@@ -16,7 +16,7 @@ RUN apt-get update && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
     apt-get update && \
     apt-get install -y --no-install-recommends yarn && \
-    npm install -g npm && \
+    npm install -g npm@^6.14 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
 

--- a/utils/Dockerfile.node.blueprint
+++ b/utils/Dockerfile.node.blueprint
@@ -18,7 +18,7 @@ RUN apt-get update && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
     apt-get update && \
     apt-get install -y --no-install-recommends yarn && \
-    npm install -g npm && \
+    npm install -g npm{{ if eq "10" $node_version }}@^6.14{{end}} && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
 


### PR DESCRIPTION
Use npm 6.x instead of npm 8.0 when using node 10.x, fixes #294 