### PR TITLE
Missing swoole onto php 7.*

### DIFF
--- a/extensions/core/docker-install.sh
+++ b/extensions/core/docker-install.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-set -e
 set -ex
 
 if [ -n "$DEV_DEPENDENCIES" ] || [ -n "$DEPENDENCIES" ]; then

--- a/extensions/core/swoole/install.sh
+++ b/extensions/core/swoole/install.sh
@@ -2,7 +2,7 @@
 
 
 set -e
-if [[ "${PHP_VERSION}" ~= "^7" ]]; then
+if [[ "${PHP_VERSION}" =~ ^7 ]]; then
   if [[ "${TARGETARCH}" == "arm64" ]]; then
     # It's too long to compile onto arm64 arch
     >&2 echo "php-swoole is not included with arm64 version (because build time is too long)"


### PR DESCRIPTION
*Summary**

This PR fixes :

* [x] Bug #333 <!-- Put `closes #333` in your comment to auto-close the issue -->

**Test plan (required)**

```
docker run -it --rm -e "PHP_EXTENSIONS=swoole" thecodingmachine/php:7.2-v4-apache php -m | grep swoole
```

**Checklist**

- [x] I followed the guidelines in [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code