### PR TITLE
chore: install mongodb from PECL

### DIFF
--- a/extensions/core/mongodb/install.sh
+++ b/extensions/core/mongodb/install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 set -e
-export EXTENSION=mongodb
+export PECL_EXTENSION=mongodb
 
 ../docker-install.sh


### PR DESCRIPTION
To access the latest versions of the mongodb extension, we can install it from PECL since it is available there.
