### PR TITLE
Install Node using the new method to avoid deprecation message delay

### DIFF
--- a/utils/Dockerfile.node.blueprint
+++ b/utils/Dockerfile.node.blueprint
@@ -17,7 +17,13 @@ ENV BLACKFIRE_VERSION=${BLACKFIRE_VERSION}
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends gnupg && \
-    curl -sL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - && \
+    if [[ "${NODE_VERSION}" -lt "16" ]]; then \
+        curl -sL https://deb.nodesource.com/setup_${NODE_VERSION}.x | sudo bash -; \
+    else \
+        sudo mkdir -p /etc/apt/keyrings && \
+        curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+        echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_VERSION.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list; \
+    fi && \
     apt-get update && \
     apt-get install -y --no-install-recommends nodejs && \
     curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \

--- a/utils/Dockerfile.slim.blueprint
+++ b/utils/Dockerfile.slim.blueprint
@@ -417,7 +417,13 @@ ONBUILD ARG NODE_VERSION
 ONBUILD RUN if [ -n "$NODE_VERSION" ]; then \
     sudo apt-get update && \
     sudo apt-get install -y --no-install-recommends gnupg && \
-    curl -sL https://deb.nodesource.com/setup_${NODE_VERSION}.x | sudo bash - && \
+    if [[ "${NODE_VERSION}" -lt "16" ]]; then \
+        curl -sL https://deb.nodesource.com/setup_${NODE_VERSION}.x | sudo bash -; \
+    else \
+        sudo mkdir -p /etc/apt/keyrings && \
+        curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+        echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_VERSION.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list; \
+    fi && \
     sudo apt-get update && \
     sudo apt-get install -y --no-install-recommends nodejs && \
     curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - && \


### PR DESCRIPTION
**Summary**

NodeSource has [deprecated the use of the installation script](https://github.com/nodesource/distributions#new-update-%EF%B8%8F). It now results in a 60s timeout when building an image with Node included.

The new repo only has v16 and above, so the change only uses the new method for v16 and above. This means that the delay may still occur for v14 and below.

This PR fixes/implements :

* [x] Bug  <!-- Put `closes #XXXX` in your comment to auto-close the issue -->
* [ ] Feature 
* [ ] Breaking changes

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Explain the **motivation** for making this change. What existing problem does the pull request solve?

Prevents a 60s wait when installing Node during builds.

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Test plan (required)**

Build the images for each Node version, and run `node --version` to check it is installed.

**Checklist**

- [x] I followed the guidelines in [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] I have squashed any insignificant commits
- [x] This change has comments for package types, values, functions, and non-obvious lines of code