### PR TITLE
Update gitlab action for node16 deprecation

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -23,16 +23,16 @@ jobs:
     name: Test ${{ matrix.php_version }}-${{ matrix.variant }} ${{ matrix.builder.arch }} only
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Docker
         # /!\ this action is marked as experimental
         # It's required only for macos
         if: ${{ matrix.builder.os == 'macos-latest' }}
         uses: docker-practice/actions-setup-docker@master
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Build
         run: |
           PHP_VERSION="${{ matrix.php_version }}"
@@ -68,13 +68,13 @@ jobs:
         variant: ['apache','cli','fpm']
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
Update to follow the gitlab action recommandation : 

Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, docker/setup-qemu-action@v2, docker/setup-buildx-action@v2. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.