### PR TITLE
fix yarn-keys-expired

### DIFF
--- a/Dockerfile.apache.node
+++ b/Dockerfile.apache.node
@@ -21,18 +21,19 @@ ENV BLACKFIRE_VERSION=${BLACKFIRE_VERSION}
 RUN apt update && \
     apt install -y --no-install-recommends gnupg && \
     if [[ "${NODE_VERSION}" -lt "16" ]]; then \
-        curl -sL --retry 5 --retry-delay 2 https://deb.nodesource.com/setup_${NODE_VERSION}.x | sudo bash -; \
+        curl -sL --retry 5 --retry-delay 2 https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash -; \
     else \
-        sudo mkdir -p /etc/apt/keyrings && \
-        curl -fsSL --retry 5 --retry-delay 2 https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
-        echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_VERSION.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list; \
+        mkdir -p /etc/apt/keyrings && \
+        curl -fsSL --retry 5 --retry-delay 2 https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+        echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_VERSION.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list; \
     fi && \
     apt update && \
     apt install -y --no-install-recommends nodejs && \
-    curl -sS --retry 5 --retry-delay 2 https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
-    apt update && \
-    apt install -y --no-install-recommends yarn && \
+    if [[ "${NODE_VERSION}" -ge "16" ]]; then \
+        corepack enable && corepack prepare yarn@stable --activate; \
+    else \
+        npm install -g yarn; \
+    fi && \
     if [[ "${NODE_VERSION}" == "10" ]]; then npm install -g npm@^6.14; fi && \
     apt clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*

--- a/Dockerfile.cli.node
+++ b/Dockerfile.cli.node
@@ -21,18 +21,19 @@ ENV BLACKFIRE_VERSION=${BLACKFIRE_VERSION}
 RUN apt update && \
     apt install -y --no-install-recommends gnupg && \
     if [[ "${NODE_VERSION}" -lt "16" ]]; then \
-        curl -sL --retry 5 --retry-delay 2 https://deb.nodesource.com/setup_${NODE_VERSION}.x | sudo bash -; \
+        curl -sL --retry 5 --retry-delay 2 https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash -; \
     else \
-        sudo mkdir -p /etc/apt/keyrings && \
-        curl -fsSL --retry 5 --retry-delay 2 https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
-        echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_VERSION.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list; \
+        mkdir -p /etc/apt/keyrings && \
+        curl -fsSL --retry 5 --retry-delay 2 https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+        echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_VERSION.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list; \
     fi && \
     apt update && \
     apt install -y --no-install-recommends nodejs && \
-    curl -sS --retry 5 --retry-delay 2 https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
-    apt update && \
-    apt install -y --no-install-recommends yarn && \
+    if [[ "${NODE_VERSION}" -ge "16" ]]; then \
+        corepack enable && corepack prepare yarn@stable --activate; \
+    else \
+        npm install -g yarn; \
+    fi && \
     if [[ "${NODE_VERSION}" == "10" ]]; then npm install -g npm@^6.14; fi && \
     apt clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*

--- a/Dockerfile.fpm.node
+++ b/Dockerfile.fpm.node
@@ -21,18 +21,19 @@ ENV BLACKFIRE_VERSION=${BLACKFIRE_VERSION}
 RUN apt update && \
     apt install -y --no-install-recommends gnupg && \
     if [[ "${NODE_VERSION}" -lt "16" ]]; then \
-        curl -sL --retry 5 --retry-delay 2 https://deb.nodesource.com/setup_${NODE_VERSION}.x | sudo bash -; \
+        curl -sL --retry 5 --retry-delay 2 https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash -; \
     else \
-        sudo mkdir -p /etc/apt/keyrings && \
-        curl -fsSL --retry 5 --retry-delay 2 https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
-        echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_VERSION.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list; \
+        mkdir -p /etc/apt/keyrings && \
+        curl -fsSL --retry 5 --retry-delay 2 https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+        echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_VERSION.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list; \
     fi && \
     apt update && \
     apt install -y --no-install-recommends nodejs && \
-    curl -sS --retry 5 --retry-delay 2 https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
-    apt update && \
-    apt install -y --no-install-recommends yarn && \
+    if [[ "${NODE_VERSION}" -ge "16" ]]; then \
+        corepack enable && corepack prepare yarn@stable --activate; \
+    else \
+        npm install -g yarn; \
+    fi && \
     if [[ "${NODE_VERSION}" == "10" ]]; then npm install -g npm@^6.14; fi && \
     apt clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*

--- a/Dockerfile.slim.apache
+++ b/Dockerfile.slim.apache
@@ -406,10 +406,11 @@ ONBUILD RUN if [ -n "$NODE_VERSION" ]; then \
     fi && \
     sudo apt update && \
     sudo apt install -y --no-install-recommends nodejs && \
-    curl -sS --retry 5 --retry-delay 2 https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - && \
-    echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list && \
-    sudo apt update && \
-    sudo apt install -y --no-install-recommends yarn && \
+    if [[ "${NODE_VERSION}" -ge "16" ]]; then \
+        sudo corepack enable && sudo corepack prepare yarn@stable --activate; \
+    else \
+        sudo npm install -g yarn; \
+    fi && \
     if [[ "${NODE_VERSION}" == "10" ]]; then sudo npm install -g npm@^6.14; fi && \
     sudo apt clean && \
     sudo rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*; \

--- a/Dockerfile.slim.cli
+++ b/Dockerfile.slim.cli
@@ -311,10 +311,11 @@ ONBUILD RUN if [ -n "$NODE_VERSION" ]; then \
     fi && \
     sudo apt update && \
     sudo apt install -y --no-install-recommends nodejs && \
-    curl -sS --retry 5 --retry-delay 2 https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - && \
-    echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list && \
-    sudo apt update && \
-    sudo apt install -y --no-install-recommends yarn && \
+    if [[ "${NODE_VERSION}" -ge "16" ]]; then \
+        sudo corepack enable && sudo corepack prepare yarn@stable --activate; \
+    else \
+        sudo npm install -g yarn; \
+    fi && \
     if [[ "${NODE_VERSION}" == "10" ]]; then sudo npm install -g npm@^6.14; fi && \
     sudo apt clean && \
     sudo rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*; \

--- a/Dockerfile.slim.fpm
+++ b/Dockerfile.slim.fpm
@@ -330,10 +330,11 @@ ONBUILD RUN if [ -n "$NODE_VERSION" ]; then \
     fi && \
     sudo apt update && \
     sudo apt install -y --no-install-recommends nodejs && \
-    curl -sS --retry 5 --retry-delay 2 https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - && \
-    echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list && \
-    sudo apt update && \
-    sudo apt install -y --no-install-recommends yarn && \
+    if [[ "${NODE_VERSION}" -ge "16" ]]; then \
+        sudo corepack enable && sudo corepack prepare yarn@stable --activate; \
+    else \
+        sudo npm install -g yarn; \
+    fi && \
     if [[ "${NODE_VERSION}" == "10" ]]; then sudo npm install -g npm@^6.14; fi && \
     sudo apt clean && \
     sudo rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*; \

--- a/utils/Dockerfile.node.blueprint
+++ b/utils/Dockerfile.node.blueprint
@@ -20,18 +20,19 @@ ENV BLACKFIRE_VERSION=${BLACKFIRE_VERSION}
 RUN apt update && \
     apt install -y --no-install-recommends gnupg && \
     if [[ "${NODE_VERSION}" -lt "16" ]]; then \
-        curl -sL --retry 5 --retry-delay 2 https://deb.nodesource.com/setup_${NODE_VERSION}.x | sudo bash -; \
+        curl -sL --retry 5 --retry-delay 2 https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash -; \
     else \
-        sudo mkdir -p /etc/apt/keyrings && \
-        curl -fsSL --retry 5 --retry-delay 2 https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
-        echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_VERSION.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list; \
+        mkdir -p /etc/apt/keyrings && \
+        curl -fsSL --retry 5 --retry-delay 2 https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+        echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_VERSION.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list; \
     fi && \
     apt update && \
     apt install -y --no-install-recommends nodejs && \
-    curl -sS --retry 5 --retry-delay 2 https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
-    apt update && \
-    apt install -y --no-install-recommends yarn && \
+    if [[ "${NODE_VERSION}" -ge "16" ]]; then \
+        corepack enable && corepack prepare yarn@stable --activate; \
+    else \
+        npm install -g yarn; \
+    fi && \
     if [[ "${NODE_VERSION}" == "10" ]]; then npm install -g npm@^6.14; fi && \
     apt clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*

--- a/utils/Dockerfile.slim.blueprint
+++ b/utils/Dockerfile.slim.blueprint
@@ -431,10 +431,11 @@ ONBUILD RUN if [ -n "$NODE_VERSION" ]; then \
     fi && \
     sudo apt update && \
     sudo apt install -y --no-install-recommends nodejs && \
-    curl -sS --retry 5 --retry-delay 2 https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - && \
-    echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list && \
-    sudo apt update && \
-    sudo apt install -y --no-install-recommends yarn && \
+    if [[ "${NODE_VERSION}" -ge "16" ]]; then \
+        sudo corepack enable && sudo corepack prepare yarn@stable --activate; \
+    else \
+        sudo npm install -g yarn; \
+    fi && \
     if [[ "${NODE_VERSION}" == "10" ]]; then sudo npm install -g npm@^6.14; fi && \
     sudo apt clean && \
     sudo rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*; \


### PR DESCRIPTION
Reading package lists... Done
W: https://dl.yarnpkg.com/debian/dists/stable/InRelease: Key is stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg), see the DEPRECATION section in apt-key(8) for details.
W: GPG error: https://dl.yarnpkg.com/debian stable InRelease: The following signatures were invalid: EXPKEYSIG 23E7166788B63E1E Yarn Packaging <yarn@dan.cx>
E: The repository 'https://dl.yarnpkg.com/debian stable InRelease' is not signed. N: Updating from such a repository can't be done securely, and is therefore disabled by default. N: See apt-secure(8) manpage for repository creation and user configuration details.


Fix #407 